### PR TITLE
fix(suggestions): Show content immediately on suggestion card tap

### DIFF
--- a/Taskweave/Sources/Services/PrioritizationService.swift
+++ b/Taskweave/Sources/Services/PrioritizationService.swift
@@ -408,7 +408,8 @@ final class PrioritizationService: ObservableObject {
 
 // MARK: - Supporting Types
 
-struct TaskSuggestion {
+struct TaskSuggestion: Identifiable {
+    var id: UUID { task.id }
     let task: Task
     let score: Double
     let reasons: [String]

--- a/Taskweave/Sources/Views/TodayView.swift
+++ b/Taskweave/Sources/Views/TodayView.swift
@@ -9,7 +9,6 @@ struct TodayView: View {
     @StateObject private var rescheduleService = SmartRescheduleService.shared
     @State private var showAddTask = false
     @State private var taskToSchedule: Task?
-    @State private var showNextTaskSuggestion = false
     @State private var taskSuggestion: TaskSuggestion?
     @State private var showConflictSheet = false
     @State private var selectedConflict: TaskConflict?
@@ -384,18 +383,16 @@ struct TodayView: View {
             )
         }
         .buttonStyle(.plain)
-        .sheet(isPresented: $showNextTaskSuggestion) {
-            if let suggestion = taskSuggestion {
-                NextTaskSuggestionSheet(suggestion: suggestion) {
-                    viewModel.selectedTask = suggestion.task
-                    showNextTaskSuggestion = false
-                } onSchedule: {
-                    taskToSchedule = suggestion.task
-                    showNextTaskSuggestion = false
-                } onStart: {
-                    // Mark as started / start timer
-                    showNextTaskSuggestion = false
-                }
+        .sheet(item: $taskSuggestion) { suggestion in
+            NextTaskSuggestionSheet(suggestion: suggestion) {
+                viewModel.selectedTask = suggestion.task
+                taskSuggestion = nil
+            } onSchedule: {
+                taskToSchedule = suggestion.task
+                taskSuggestion = nil
+            } onStart: {
+                // Mark as started / start timer
+                taskSuggestion = nil
             }
         }
     }
@@ -405,7 +402,6 @@ struct TodayView: View {
             if let suggestion = await prioritizationService.getNextTaskSuggestion() {
                 await MainActor.run {
                     taskSuggestion = suggestion
-                    showNextTaskSuggestion = true
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Fix blank screen when tapping "What should I do next?" AI suggestion card
- Use `.sheet(item:)` instead of `.sheet(isPresented:)` to eliminate race condition

## Root Cause
The original code used separate state variables:
- `showNextTaskSuggestion: Bool` - controls sheet presentation
- `taskSuggestion: TaskSuggestion?` - holds the data

When the sheet opened, the `if let suggestion = taskSuggestion` inside the content builder could evaluate to `nil` due to SwiftUI's state capture timing.

## Fix
Use `.sheet(item:)` which only presents when the item is non-nil and passes the unwrapped value directly to the content builder.

## Test Plan
- [x] Tap "What should I do next?" card
- [x] Verify sheet shows content immediately (no blank screen)
- [x] Verify priority score, task details, and AI insight are visible

Closes #19