### PR TITLE
feat(tasks): Add 'In Progress' task state and improve repeat frequency display

### DIFF
--- a/Taskweave/Sources/Models/RecurringRule.swift
+++ b/Taskweave/Sources/Models/RecurringRule.swift
@@ -136,6 +136,27 @@ struct RecurringRule: Codable, Equatable, Hashable {
         return description
     }
 
+    /// Compact format for display in task cards (e.g., "1d", "1w", "3/wk")
+    var compactDisplayFormat: String {
+        switch frequency {
+        case .daily:
+            return interval == 1 ? "1d" : "\(interval)d"
+        case .weekly:
+            if let days = daysOfWeek, !days.isEmpty {
+                return "\(days.count)/wk"
+            }
+            return interval == 1 ? "1w" : "\(interval)w"
+        case .biweekly:
+            return "2w"
+        case .monthly:
+            return interval == 1 ? "1mo" : "\(interval)mo"
+        case .yearly:
+            return interval == 1 ? "1y" : "\(interval)y"
+        case .custom:
+            return "\(interval)d"
+        }
+    }
+
     private var frequencyUnit: String {
         switch frequency {
         case .daily: return interval == 1 ? "day" : "days"

--- a/Taskweave/Sources/Models/Taskweave.xcdatamodeld/Taskweave.xcdatamodel/contents
+++ b/Taskweave/Sources/Models/Taskweave.xcdatamodeld/Taskweave.xcdatamodel/contents
@@ -14,6 +14,7 @@
         <attribute name="notes" optional="YES" attributeType="String"/>
         <attribute name="priorityRaw" attributeType="Integer 16" defaultValueString="1" usesScalarValueType="YES"/>
         <attribute name="reminderDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="statusRaw" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="title" attributeType="String"/>
         <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="list" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TaskListEntity" inverseName="tasks" inverseEntity="TaskListEntity"/>

--- a/Taskweave/Sources/ViewModels/TodayViewModel.swift
+++ b/Taskweave/Sources/ViewModels/TodayViewModel.swift
@@ -89,6 +89,14 @@ final class TodayViewModel: ObservableObject {
         taskService.updateTask(updatedTask)
     }
 
+    func startWorking(on task: Task) {
+        taskService.startWorking(on: task)
+    }
+
+    func stopWorking(on task: Task) {
+        taskService.stopWorking(on: task)
+    }
+
     func createTask(title: String, priority: Priority = .none) {
         taskService.createTask(
             title: title,

--- a/Taskweave/Sources/Views/ListDetailView.swift
+++ b/Taskweave/Sources/Views/ListDetailView.swift
@@ -92,7 +92,9 @@ struct ListDetailView: View {
                             onMoveToToday: { moveToToday($0) },
                             onPriorityChange: { updateTaskPriority($0, priority: $1) },
                             onDueDateChange: { updateTaskDueDate($0, dueDate: $1) },
-                            onDelete: { taskService.deleteTask($0) }
+                            onDelete: { taskService.deleteTask($0) },
+                            onStartWorking: { taskService.startWorking(on: $0) },
+                            onStopWorking: { taskService.stopWorking(on: $0) }
                         )
                         .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
                         .listRowBackground(Color.adaptiveBackground)
@@ -125,7 +127,9 @@ struct ListDetailView: View {
                                 onMoveToToday: { moveToToday($0) },
                                 onPriorityChange: { updateTaskPriority($0, priority: $1) },
                                 onDueDateChange: { updateTaskDueDate($0, dueDate: $1) },
-                                onDelete: { taskService.deleteTask($0) }
+                                onDelete: { taskService.deleteTask($0) },
+                                onStartWorking: nil,
+                                onStopWorking: nil
                             )
                             .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
                             .listRowBackground(Color.adaptiveBackground)

--- a/Taskweave/Sources/Views/TaskDetailView.swift
+++ b/Taskweave/Sources/Views/TaskDetailView.swift
@@ -113,6 +113,14 @@ struct TaskDetailView: View {
                             }
                         }
 
+                        if viewModel.recurringFrequency == .custom {
+                            Stepper(
+                                "Every \(viewModel.recurringInterval) day\(viewModel.recurringInterval == 1 ? "" : "s")",
+                                value: $viewModel.recurringInterval,
+                                in: 1...365
+                            )
+                        }
+
                         if viewModel.recurringFrequency == .weekly {
                             weekdayPicker
                         }

--- a/Taskweave/Sources/Views/TodayView.swift
+++ b/Taskweave/Sources/Views/TodayView.swift
@@ -464,7 +464,9 @@ struct TodayView: View {
                     onDelete: { task in
                         showUndoToast(.deleted(task), snapshot: task)
                         viewModel.deleteTask(task)
-                    }
+                    },
+                    onStartWorking: { viewModel.startWorking(on: $0) },
+                    onStopWorking: { viewModel.stopWorking(on: $0) }
                 )
                 .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
                 .listRowBackground(Color.adaptiveBackground)
@@ -500,7 +502,9 @@ struct TodayView: View {
                     onPushToTomorrow: nil,
                     onPriorityChange: { viewModel.updateTaskPriority($0, priority: $1) },
                     onDueDateChange: { viewModel.updateTaskDueDate($0, dueDate: $1) },
-                    onDelete: { viewModel.deleteTask($0) }
+                    onDelete: { viewModel.deleteTask($0) },
+                    onStartWorking: nil,
+                    onStopWorking: nil
                 )
                 .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
                 .listRowBackground(Color.adaptiveBackground)

--- a/Taskweave/Sources/Views/UpcomingView.swift
+++ b/Taskweave/Sources/Views/UpcomingView.swift
@@ -98,7 +98,9 @@ struct UpcomingView: View {
                             onMoveToToday: { moveToToday($0) },
                             onPriorityChange: { updateTaskPriority($0, priority: $1) },
                             onDueDateChange: { updateTaskDueDate($0, dueDate: $1) },
-                            onDelete: { taskService.deleteTask($0) }
+                            onDelete: { taskService.deleteTask($0) },
+                            onStartWorking: { taskService.startWorking(on: $0) },
+                            onStopWorking: { taskService.stopWorking(on: $0) }
                         )
                         .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
                         .listRowBackground(Color.adaptiveBackground)
@@ -121,7 +123,9 @@ struct UpcomingView: View {
                             onMoveToToday: { moveToToday($0) },
                             onPriorityChange: { updateTaskPriority($0, priority: $1) },
                             onDueDateChange: { updateTaskDueDate($0, dueDate: $1) },
-                            onDelete: { taskService.deleteTask($0) }
+                            onDelete: { taskService.deleteTask($0) },
+                            onStartWorking: { taskService.startWorking(on: $0) },
+                            onStopWorking: { taskService.stopWorking(on: $0) }
                         )
                         .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
                         .listRowBackground(Color.adaptiveBackground)


### PR DESCRIPTION
## Summary
- **Added "In Progress" task state** - Tasks can now be marked as "in progress" via swipe actions (Start/Pause) or context menu
- **New checkbox indicator** - Tasks being worked on show a pulsing teal dot inside the checkbox circle
- **Single active task enforcement** - Starting work on a task automatically pauses any other in-progress task
- **Compact repeat frequency display** - Recurring tasks now show their frequency (1d, 1w, 2w, 1mo, 3/wk) next to the repeat icon
- **Custom repeat interval** - Added stepper to set custom day intervals (1-365 days) when using "Custom" frequency

## Changes
- `Task.swift` - Added `TaskStatus` enum (pending, inProgress, completed) and helper methods
- `RecurringRule.swift` - Added `compactDisplayFormat` computed property
- `TaskRowView.swift` - Updated checkbox with pulsing dot, added repeat frequency display, Start/Pause swipe actions
- `TaskDetailView.swift` - Added interval stepper for custom frequency
- `TaskService.swift` - Added `startWorking(on:)` and `stopWorking(on:)` methods
- Core Data model - Added `statusRaw` attribute with default value for backward compatibility

## Test plan
- [x] Create a task and swipe left to tap "Start" - checkbox shows pulsing teal dot
- [x] While task is in progress, start working on another task - first task automatically pauses
- [x] Swipe left on in-progress task and tap "Pause" - dot disappears
- [x] Create recurring task with different frequencies and verify compact format displays correctly
- [x] Set custom repeat frequency and verify interval stepper works (1-365 days)
- [x] Complete an in-progress task - transitions to completed state correctly

Closes #17