### PR TITLE
fix(calendar): Fix blank Create Task from Event sheet

### DIFF
--- a/Taskweave/Sources/Views/CalendarView.swift
+++ b/Taskweave/Sources/Views/CalendarView.swift
@@ -10,7 +10,6 @@ struct CalendarView: View {
     @State private var showingTimeBlockSheet = false
     @State private var pendingTask: Task?
     @State private var pendingDropTime: Date?
-    @State private var showingCreateTaskSheet = false
     @State private var eventToConvert: CalendarEvent?
     @State private var showingDeniedAlert = false
 
@@ -29,11 +28,9 @@ struct CalendarView: View {
                         }
                     }
                 }
-                .sheet(isPresented: $showingCreateTaskSheet) {
-                    if let event = eventToConvert {
-                        CreateTaskFromEventSheet(event: event) { task in
-                            createTaskFromEvent(task)
-                        }
+                .sheet(item: $eventToConvert) { event in
+                    CreateTaskFromEventSheet(event: event) { task in
+                        createTaskFromEvent(task)
                     }
                 }
                 .alert("Calendar Access Denied", isPresented: $showingDeniedAlert) {
@@ -61,11 +58,9 @@ struct CalendarView: View {
                             }
                         }
                     }
-                    .sheet(isPresented: $showingCreateTaskSheet) {
-                        if let event = eventToConvert {
-                            CreateTaskFromEventSheet(event: event) { task in
-                                createTaskFromEvent(task)
-                            }
+                    .sheet(item: $eventToConvert) { event in
+                        CreateTaskFromEventSheet(event: event) { task in
+                            createTaskFromEvent(task)
                         }
                     }
                     .alert("Calendar Access Denied", isPresented: $showingDeniedAlert) {
@@ -127,7 +122,6 @@ struct CalendarView: View {
                             },
                             onCreateTaskFromEvent: { event in
                                 eventToConvert = event
-                                showingCreateTaskSheet = true
                             }
                         )
                     case .week:
@@ -142,7 +136,6 @@ struct CalendarView: View {
                             },
                             onCreateTaskFromEvent: { event in
                                 eventToConvert = event
-                                showingCreateTaskSheet = true
                             }
                         )
                     }
@@ -168,15 +161,13 @@ struct CalendarView: View {
                     )
                 }
             }
-            .sheet(isPresented: $showingCreateTaskSheet) {
-                if let event = eventToConvert {
-                    CreateTaskFromEventSheet(
-                        event: event,
-                        onConfirm: { task in
-                            createTaskFromEvent(task)
-                        }
-                    )
-                }
+            .sheet(item: $eventToConvert) { event in
+                CreateTaskFromEventSheet(
+                    event: event,
+                    onConfirm: { task in
+                        createTaskFromEvent(task)
+                    }
+                )
             }
     }
 


### PR DESCRIPTION
## Summary
- Change sheet presentation from `.sheet(isPresented:)` to `.sheet(item:)` pattern
- Ensures the event data is guaranteed to exist when the sheet renders
- Remove redundant `showingCreateTaskSheet` state variable

## Test plan
- [x] Open Calendar tab
- [x] Switch to Day view
- [x] Long press on a calendar event
- [x] Tap "Create Task" from context menu
- [x] Verify the sheet displays all content (event info, task details, priority, due date)
- [x] Tested on simulator
- [x] Tested on physical device

Closes #38