### PR TITLE
feat(widget): Add deep linking for widget tap navigation

### DIFF
--- a/Taskweave/Resources/Info.plist
+++ b/Taskweave/Resources/Info.plist
@@ -56,5 +56,16 @@
 			<dict/>
 		</dict>
 	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.taskweave.app</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>taskweave</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/Taskweave/Sources/App/TaskweaveApp.swift
+++ b/Taskweave/Sources/App/TaskweaveApp.swift
@@ -15,6 +15,9 @@ struct TaskweaveApp: App {
     var body: some Scene {
         WindowGroup {
             RootView()
+                .onOpenURL { url in
+                    handleDeepLink(url)
+                }
         }
         .commands {
             // Keyboard shortcuts for iPad
@@ -73,6 +76,13 @@ struct TaskweaveApp: App {
         navBarAppearance.configureWithDefaultBackground()
         UINavigationBar.appearance().standardAppearance = navBarAppearance
         UINavigationBar.appearance().scrollEdgeAppearance = navBarAppearance
+    }
+
+    private func handleDeepLink(_ url: URL) {
+        guard url.scheme == "taskweave" else { return }
+        if url.host == "view", let path = url.pathComponents.last {
+            NotificationCenter.default.post(name: .navigateToTab, object: path)
+        }
     }
 }
 

--- a/TaskweaveWidget/Views/LargeWidgetView.swift
+++ b/TaskweaveWidget/Views/LargeWidgetView.swift
@@ -67,6 +67,7 @@ struct LargeWidgetView: View {
         .containerBackground(for: .widget) {
             Color(.systemBackground)
         }
+        .widgetURL(URL(string: "taskweave://view/today"))
     }
 }
 

--- a/TaskweaveWidget/Views/MediumWidgetView.swift
+++ b/TaskweaveWidget/Views/MediumWidgetView.swift
@@ -66,6 +66,7 @@ struct MediumWidgetView: View {
         .containerBackground(for: .widget) {
             Color(.systemBackground)
         }
+        .widgetURL(URL(string: "taskweave://view/today"))
     }
 }
 

--- a/TaskweaveWidget/Views/SmallWidgetView.swift
+++ b/TaskweaveWidget/Views/SmallWidgetView.swift
@@ -77,6 +77,7 @@ struct SmallWidgetView: View {
         .containerBackground(for: .widget) {
             Color(.systemBackground)
         }
+        .widgetURL(URL(string: "taskweave://view/today"))
     }
 }
 


### PR DESCRIPTION
## Summary
- Tapping a widget now opens the app directly to the Today tab
- Uses `taskweave://` URL scheme for deep linking
- Supports navigation to any tab via `taskweave://view/{tab}`

## Changes
- Register `taskweave://` URL scheme in Info.plist
- Add `onOpenURL` handler in TaskweaveApp to process deep links
- Add `.widgetURL()` modifier to Small, Medium, and Large widget views

## Test plan
- [x] Tap widget while app is closed → launches to Today tab
- [x] Tap widget while app is in background → brings app to Today tab
- [x] Tap widget while app is on different tab → switches to Today tab
- [x] Deep link to other tabs (calendar, settings) works

Closes #20