### PR TITLE
feat(calendar): Add error toast for calendar sync failures

### DIFF
--- a/Taskweave/Sources/Views/CalendarView.swift
+++ b/Taskweave/Sources/Views/CalendarView.swift
@@ -147,6 +147,7 @@ struct CalendarView: View {
                     noAccessView
                 }
             }
+            .errorToast(message: $viewModel.errorMessage)
     }
 
     // MARK: - Sheets Modifier


### PR DESCRIPTION
## Summary
- Add `ErrorToastView` component for displaying calendar sync failure messages
- Add `ErrorToastModifier` with `.errorToast()` view modifier for easy integration
- Wire up error toast in `CalendarView` to display sync errors from `CalendarViewModel.errorMessage`

This completes Issue #5 by adding toast notifications for calendar sync failures. The permission denied handling (banner, alert, Open Settings button) was previously implemented in PR #26.

## Test plan
- [x] Grant calendar access, then drag a task to calendar to create a time block
- [x] Simulate a sync failure by creating invalid time block scenario
- [x] Verify error toast appears at bottom of screen
- [x] Verify toast auto-dismisses after 4 seconds
- [x] Verify swipe-down gesture dismisses toast early
- [x] Verify tap on X button dismisses toast

## Tested on
- iPhone 17 Pro Simulator (iOS 26.2)

Closes #5