### PR TITLE
feat(sync): add iCloud sync with CloudKit

### DIFF
--- a/Taskweave/Taskweave.entitlements
+++ b/Taskweave/Taskweave.entitlements
@@ -2,6 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.taskweave.app</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.taskweave.shared</string>


### PR DESCRIPTION
## Summary
- Enable iCloud sync for tasks and lists using `NSPersistentCloudKitContainer`
- CloudKit container `iCloud.com.taskweave.app` configured in Apple Developer portal
- Automatic sync when iCloud is available, graceful fallback to local storage

## Changes
- Switch from `NSPersistentContainer` to `NSPersistentCloudKitContainer`
- Add CloudKit container identifier and options
- Add remote change notification observer for sync updates
- Add CloudKit entitlements (`com.apple.developer.icloud-container-identifiers`, `com.apple.developer.icloud-services`)
- Fallback to local storage when iCloud unavailable

## Test plan
- [x] App builds successfully
- [x] App runs without crashes on iPhone and iPad
- [x] Local data persistence works (tasks saved after restart)
- [x] CRUD operations work (create, complete, view tasks)
- [x] CloudKit container exists in Apple Developer portal
- [ ] Cross-device sync (requires physical devices with same iCloud account)

## Notes
- Simulator CloudKit sync is unreliable (Apple limitation)
- Full sync testing recommended on physical devices

Closes #30