### PR TITLE
fix(sync): improve CloudKit sync reliability and UI refresh

### DIFF
--- a/Taskweave/Resources/Info.plist
+++ b/Taskweave/Resources/Info.plist
@@ -67,5 +67,9 @@
 			</array>
 		</dict>
 	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 </dict>
 </plist>

--- a/Taskweave/Sources/Models/Taskweave.xcdatamodeld/Taskweave.xcdatamodel/contents
+++ b/Taskweave/Sources/Models/Taskweave.xcdatamodeld/Taskweave.xcdatamodel/contents
@@ -3,11 +3,11 @@
     <entity name="TaskEntity" representedClassName="TaskEntity" syncable="YES" codeGenerationType="class">
         <attribute name="categoryRaw" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="completedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="dueDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="dueTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="estimatedDuration" optional="YES" attributeType="Double" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="isArchived" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="isCompleted" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="linkedEventID" optional="YES" attributeType="String"/>
@@ -15,18 +15,18 @@
         <attribute name="priorityRaw" attributeType="Integer 16" defaultValueString="1" usesScalarValueType="YES"/>
         <attribute name="reminderDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="statusRaw" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="title" attributeType="String"/>
-        <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="title" optional="YES" attributeType="String" defaultValueString=""/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="list" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TaskListEntity" inverseName="tasks" inverseEntity="TaskListEntity"/>
         <relationship name="recurringRule" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="RecurringRuleEntity" inverseName="task" inverseEntity="RecurringRuleEntity"/>
     </entity>
     <entity name="TaskListEntity" representedClassName="TaskListEntity" syncable="YES" codeGenerationType="class">
         <attribute name="colorHex" attributeType="String" defaultValueString="#218A8D"/>
-        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="iconName" optional="YES" attributeType="String"/>
-        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="isDefault" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
-        <attribute name="name" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String" defaultValueString=""/>
         <attribute name="order" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="tasks" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TaskEntity" inverseName="list" inverseEntity="TaskEntity"/>
     </entity>
@@ -34,7 +34,7 @@
         <attribute name="daysOfWeek" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="NSArray"/>
         <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="frequencyRaw" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="interval" attributeType="Integer 16" defaultValueString="1" usesScalarValueType="YES"/>
         <relationship name="task" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TaskEntity" inverseName="recurringRule" inverseEntity="TaskEntity"/>
     </entity>

--- a/Taskweave/Sources/Services/TaskListService.swift
+++ b/Taskweave/Sources/Services/TaskListService.swift
@@ -22,7 +22,16 @@ final class TaskListService: ObservableObject {
     // MARK: - Setup
 
     private func setupObservers() {
+        // Listen for local Core Data saves
         NotificationCenter.default.publisher(for: .NSManagedObjectContextDidSave)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.fetchAllLists()
+            }
+            .store(in: &cancellables)
+
+        // Listen for CloudKit sync completion (remote changes)
+        NotificationCenter.default.publisher(for: .cloudKitSyncDidComplete)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.fetchAllLists()

--- a/Taskweave/Sources/Services/TaskService.swift
+++ b/Taskweave/Sources/Services/TaskService.swift
@@ -31,7 +31,16 @@ final class TaskService: ObservableObject {
     // MARK: - Setup
 
     private func setupObservers() {
+        // Listen for local Core Data saves
         NotificationCenter.default.publisher(for: .NSManagedObjectContextDidSave)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.fetchAllTasks()
+            }
+            .store(in: &cancellables)
+
+        // Listen for CloudKit sync completion (remote changes)
+        NotificationCenter.default.publisher(for: .cloudKitSyncDidComplete)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.fetchAllTasks()


### PR DESCRIPTION
## Summary
- Make Core Data attributes optional for CloudKit compatibility
- Add `remote-notification` background mode for CloudKit push notifications
- Wait for persistent store to load before performing operations
- Add guards to prevent Core Data operations before store is ready
- Refresh UI automatically when CloudKit sync completes
- Add `cloudKitSyncDidComplete` observer to TaskService and TaskListService

## Test plan
- [x] Create task on device
- [x] Delete app
- [x] Reinstall app
- [x] Verify task is restored from iCloud automatically (without restart)

Fixes remaining issues from #50
Related to #30 (iCloud sync with CloudKit)