### PR TITLE
feat(accessibility): Add VoiceOver support for task rows and Watch app

### DIFF
--- a/Taskweave/Sources/Utilities/DesignSystem.swift
+++ b/Taskweave/Sources/Utilities/DesignSystem.swift
@@ -191,6 +191,7 @@ struct PriorityBadge: View {
             .background(priority.color.opacity(0.15))
             .cornerRadius(DesignSystem.CornerRadius.small)
             .fixedSize()
+            .accessibilityHidden(true) // Info conveyed via parent row label
         }
     }
 }
@@ -217,6 +218,7 @@ struct DueDateBadge: View {
         )
         .cornerRadius(DesignSystem.CornerRadius.small)
         .fixedSize()
+        .accessibilityHidden(true) // Info conveyed via parent row label
     }
 }
 
@@ -238,6 +240,7 @@ struct CategoryBadge: View {
             .background(category.color.opacity(0.15))
             .cornerRadius(DesignSystem.CornerRadius.small)
             .fixedSize()
+            .accessibilityHidden(true) // Info conveyed via parent row label
         }
     }
 }
@@ -249,6 +252,7 @@ struct ListColorDot: View {
         Circle()
             .fill(Color(hex: colorHex) ?? .gray)
             .frame(width: 12, height: 12)
+            .accessibilityHidden(true) // Decorative element
     }
 }
 

--- a/Taskweave/Sources/Views/TaskRowView.swift
+++ b/Taskweave/Sources/Views/TaskRowView.swift
@@ -463,6 +463,32 @@ struct CompactTaskRowView: View {
             .padding(.leading, task.priority != .none && !task.isCompleted ? DesignSystem.Spacing.sm : 0)
         }
         .padding(.vertical, DesignSystem.Spacing.xs)
+        .accessibilityLabel(accessibilityDescription)
+        .accessibilityHint("Double tap to toggle completion")
+    }
+
+    private var accessibilityDescription: String {
+        var components: [String] = []
+
+        if task.isCompleted {
+            components.append("Completed")
+        }
+
+        components.append(task.title)
+
+        if task.priority != .none && !task.isCompleted {
+            components.append("\(task.priority.displayName) priority")
+        }
+
+        if let date = task.dueDate {
+            if task.isOverdue {
+                components.append("Overdue")
+            } else {
+                components.append("Due \(date.shortFormatted)")
+            }
+        }
+
+        return components.joined(separator: ", ")
     }
 }
 

--- a/TaskweaveWatch/Sources/Views/WatchTaskRowView.swift
+++ b/TaskweaveWatch/Sources/Views/WatchTaskRowView.swift
@@ -41,6 +41,46 @@ struct WatchTaskRowView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityDescription)
+        .accessibilityHint("Double tap to mark as \(task.isCompleted ? "incomplete" : "complete")")
+    }
+
+    // MARK: - Accessibility
+
+    private var accessibilityDescription: String {
+        var components: [String] = []
+
+        // Status
+        if task.isCompleted {
+            components.append("Completed")
+        }
+
+        // Title
+        components.append(task.title)
+
+        // Priority
+        if task.priority > 1 {
+            components.append("\(priorityName) priority")
+        }
+
+        // Due time
+        if task.isOverdue {
+            components.append("Overdue")
+        } else if task.dueTime != nil {
+            components.append("Due today")
+        }
+
+        return components.joined(separator: ", ")
+    }
+
+    private var priorityName: String {
+        switch task.priority {
+        case 4: return "Urgent"
+        case 3: return "High"
+        case 2: return "Medium"
+        case 1: return "Low"
+        default: return ""
+        }
     }
 
     private var checkboxView: some View {


### PR DESCRIPTION
## Summary
Adds VoiceOver accessibility support for task rows across iPhone and Apple Watch apps, ensuring users with visual impairments can navigate and interact with tasks effectively.

**Changes:**
- Add accessibility labels to WatchTaskRowView announcing status, title, priority, and due time
- Add accessibility labels and hints to CompactTaskRowView
- Mark decorative badge components (DueDateBadge, CategoryBadge, PriorityBadge, ListColorDot) as accessibilityHidden to prevent duplicate announcements

## Test plan
- [x] Build succeeds
- [x] VoiceOver announces task details correctly on simulator
- [x] VoiceOver announces task details correctly on physical device

Closes #6