### PR TITLE
feat(onboarding): Add tutorial carousel for first-time users

### DIFF
--- a/Taskweave.xcodeproj/project.pbxproj
+++ b/Taskweave.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		F96E3F362C44485C5C35A2C8 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 751D60DB44ED6F070A0B42EA /* ContentView.swift */; };
 		FC9544F1BAA698EA4127635A /* Notification+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ECD280716254E849E7546A7 /* Notification+Extensions.swift */; };
 		FD1234567890ABCD12345679 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE1234567890ABCD12345679 /* RootView.swift */; };
+		74E02FAFA3474326A4B13BBA /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5422C0354A3547D29987A46C /* OnboardingView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -249,6 +250,7 @@
 		F970C9D8C8571D12DA3516C4 /* ListsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListsViewModel.swift; sourceTree = "<group>"; };
 		FBCA0FA9E06FCD309828CC12 /* WatchEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchEmptyStateView.swift; sourceTree = "<group>"; };
 		FE1234567890ABCD12345679 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		5422C0354A3547D29987A46C /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -350,6 +352,7 @@
 				E792CF309818E6413FAEA8E0 /* ListDetailView.swift */,
 				A02B96740C9B26528CA1981D /* ListsView.swift */,
 				3295E36A41D180A3D0E9DA4B /* SearchView.swift */,
+				5422C0354A3547D29987A46C /* OnboardingView.swift */,
 				45B38F1755E8984C7F33C03E /* SettingsView.swift */,
 				FE1234567890ABCD12345679 /* RootView.swift */,
 				DB9710240F152BBE69A5E1FE /* TaskDetailView.swift */,
@@ -769,6 +772,7 @@
 				608DB00EAEAA45A51D1A9899 /* CompleteTaskIntent.swift in Sources */,
 				407E19F80003AD5F28E97D2B /* ConflictDetectionService.swift in Sources */,
 				F96E3F362C44485C5C35A2C8 /* ContentView.swift in Sources */,
+				74E02FAFA3474326A4B13BBA /* OnboardingView.swift in Sources */,
 				28B504DD93A864BB789BAAA3 /* CreateTaskIntent.swift in Sources */,
 				6718A8DF9783D2257A96B7D5 /* Date+Extensions.swift in Sources */,
 				85F5AEDB30CBD2E06B5DB537 /* DesignSystem.swift in Sources */,

--- a/Taskweave/Sources/Views/OnboardingView.swift
+++ b/Taskweave/Sources/Views/OnboardingView.swift
@@ -1,0 +1,291 @@
+import SwiftUI
+import EventKit
+import UserNotifications
+
+/// Onboarding tutorial carousel for first-time users
+struct OnboardingView: View {
+    @AppStorage("hasSeenOnboarding") private var hasCompletedOnboarding = false
+    @State private var currentPage = 0
+    @State private var calendarPermissionGranted = false
+    @State private var notificationPermissionGranted = false
+
+    private let pages: [OnboardingPage] = [
+        OnboardingPage(
+            icon: "checkmark.circle.fill",
+            title: "Welcome to Taskweave",
+            description: "Your calendar-first task manager that helps you get things done.",
+            accentColor: Color.Taskweave.accent
+        ),
+        OnboardingPage(
+            icon: "calendar.badge.clock",
+            title: "Calendar Integration",
+            description: "Seamlessly schedule tasks as time blocks on your calendar. See your tasks alongside meetings.",
+            accentColor: .blue
+        ),
+        OnboardingPage(
+            icon: "sparkles",
+            title: "AI-Powered Suggestions",
+            description: "Get smart recommendations on what to do next based on your priorities and schedule.",
+            accentColor: .purple
+        )
+    ]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Skip button
+            HStack {
+                Spacer()
+                if currentPage < pages.count {
+                    Button("Skip") {
+                        completeOnboarding()
+                    }
+                    .font(.subheadline)
+                    .foregroundColor(Color.Taskweave.textSecondary)
+                    .padding()
+                }
+            }
+
+            Spacer()
+
+            // Content
+            TabView(selection: $currentPage) {
+                ForEach(0..<pages.count, id: \.self) { index in
+                    OnboardingPageView(page: pages[index])
+                        .tag(index)
+                }
+
+                // Final page: Permissions
+                PermissionsPageView(
+                    calendarGranted: $calendarPermissionGranted,
+                    notificationsGranted: $notificationPermissionGranted
+                )
+                .tag(pages.count)
+            }
+            .tabViewStyle(.page(indexDisplayMode: .never))
+            .animation(.easeInOut, value: currentPage)
+
+            Spacer()
+
+            // Page indicator
+            HStack(spacing: 8) {
+                ForEach(0...pages.count, id: \.self) { index in
+                    Circle()
+                        .fill(index == currentPage ? Color.Taskweave.accent : Color.Taskweave.textTertiary.opacity(0.3))
+                        .frame(width: 8, height: 8)
+                        .animation(.easeInOut, value: currentPage)
+                }
+            }
+            .padding(.bottom, 24)
+
+            // Action button
+            Button {
+                if currentPage < pages.count {
+                    withAnimation {
+                        currentPage += 1
+                    }
+                } else {
+                    completeOnboarding()
+                }
+            } label: {
+                Text(currentPage < pages.count ? "Continue" : "Get Started")
+                    .font(.headline)
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 50)
+                    .background(Color.Taskweave.accent)
+                    .cornerRadius(12)
+            }
+            .padding(.horizontal, 24)
+            .padding(.bottom, 40)
+        }
+        .background(Color.adaptiveBackground)
+    }
+
+    private func completeOnboarding() {
+        withAnimation {
+            hasCompletedOnboarding = true
+        }
+    }
+}
+
+// MARK: - Onboarding Page Model
+
+private struct OnboardingPage {
+    let icon: String
+    let title: String
+    let description: String
+    let accentColor: Color
+}
+
+// MARK: - Onboarding Page View
+
+private struct OnboardingPageView: View {
+    let page: OnboardingPage
+
+    var body: some View {
+        VStack(spacing: 24) {
+            // Icon
+            Image(systemName: page.icon)
+                .font(.system(size: 80))
+                .foregroundColor(page.accentColor)
+                .padding(.bottom, 16)
+
+            // Title
+            Text(page.title)
+                .font(.title.bold())
+                .foregroundColor(Color.Taskweave.textPrimary)
+                .multilineTextAlignment(.center)
+
+            // Description
+            Text(page.description)
+                .font(.body)
+                .foregroundColor(Color.Taskweave.textSecondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+        }
+        .padding()
+    }
+}
+
+// MARK: - Permissions Page View
+
+private struct PermissionsPageView: View {
+    @Binding var calendarGranted: Bool
+    @Binding var notificationsGranted: Bool
+
+    var body: some View {
+        VStack(spacing: 24) {
+            // Icon
+            Image(systemName: "bell.badge.fill")
+                .font(.system(size: 80))
+                .foregroundColor(.orange)
+                .padding(.bottom, 16)
+
+            // Title
+            Text("Stay on Track")
+                .font(.title.bold())
+                .foregroundColor(Color.Taskweave.textPrimary)
+                .multilineTextAlignment(.center)
+
+            // Description
+            Text("Enable permissions for the best experience.")
+                .font(.body)
+                .foregroundColor(Color.Taskweave.textSecondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+
+            // Permission buttons
+            VStack(spacing: 16) {
+                PermissionRow(
+                    icon: "calendar",
+                    title: "Calendar Access",
+                    description: "Schedule tasks as time blocks",
+                    isGranted: calendarGranted,
+                    action: requestCalendarPermission
+                )
+
+                PermissionRow(
+                    icon: "bell.fill",
+                    title: "Notifications",
+                    description: "Get reminded about tasks",
+                    isGranted: notificationsGranted,
+                    action: requestNotificationPermission
+                )
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 16)
+        }
+        .padding()
+        .onAppear {
+            checkExistingPermissions()
+        }
+    }
+
+    private func checkExistingPermissions() {
+        // Check calendar
+        let calendarStatus = EKEventStore.authorizationStatus(for: .event)
+        calendarGranted = calendarStatus == .fullAccess
+
+        // Check notifications
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            DispatchQueue.main.async {
+                notificationsGranted = settings.authorizationStatus == .authorized
+            }
+        }
+    }
+
+    private func requestCalendarPermission() {
+        let eventStore = EKEventStore()
+        eventStore.requestFullAccessToEvents { granted, _ in
+            DispatchQueue.main.async {
+                calendarGranted = granted
+            }
+        }
+    }
+
+    private func requestNotificationPermission() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { granted, _ in
+            DispatchQueue.main.async {
+                notificationsGranted = granted
+            }
+        }
+    }
+}
+
+// MARK: - Permission Row
+
+private struct PermissionRow: View {
+    let icon: String
+    let title: String
+    let description: String
+    let isGranted: Bool
+    let action: () -> Void
+
+    var body: some View {
+        HStack(spacing: 16) {
+            // Icon
+            Image(systemName: icon)
+                .font(.title2)
+                .foregroundColor(Color.Taskweave.accent)
+                .frame(width: 44, height: 44)
+                .background(Color.Taskweave.accent.opacity(0.1))
+                .cornerRadius(10)
+
+            // Text
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(Color.Taskweave.textPrimary)
+                Text(description)
+                    .font(.caption)
+                    .foregroundColor(Color.Taskweave.textSecondary)
+            }
+
+            Spacer()
+
+            // Status/Button
+            if isGranted {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundColor(Color.Taskweave.success)
+                    .font(.title2)
+            } else {
+                Button("Enable") {
+                    action()
+                }
+                .font(.subheadline.weight(.medium))
+                .foregroundColor(.white)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+                .background(Color.Taskweave.accent)
+                .cornerRadius(8)
+            }
+        }
+        .padding()
+        .background(Color.adaptiveSurface)
+        .cornerRadius(12)
+    }
+}
+
+#Preview {
+    OnboardingView()
+}

--- a/Taskweave/Sources/Views/RootView.swift
+++ b/Taskweave/Sources/Views/RootView.swift
@@ -7,22 +7,28 @@ struct RootView: View {
     @State private var taskService: TaskService?
     @State private var isLoading = true
     @State private var showContent = false
+    @AppStorage("hasSeenOnboarding") private var hasCompletedOnboarding = false
 
     var body: some View {
         ZStack {
             if let controller = persistenceController,
                let service = taskService,
                showContent {
-                ContentView()
-                    .environment(\.managedObjectContext, controller.viewContext)
-                    .environmentObject(service)
-                    .transition(.opacity.combined(with: .scale(scale: 0.98)))
-                    .onAppear {
-                        WatchConnectivityService.shared.configure(with: service)
-                    }
-                    .task {
-                        controller.createDefaultListsIfNeeded()
-                    }
+                if hasCompletedOnboarding {
+                    ContentView()
+                        .environment(\.managedObjectContext, controller.viewContext)
+                        .environmentObject(service)
+                        .transition(.opacity.combined(with: .scale(scale: 0.98)))
+                        .onAppear {
+                            WatchConnectivityService.shared.configure(with: service)
+                        }
+                        .task {
+                            controller.createDefaultListsIfNeeded()
+                        }
+                } else {
+                    OnboardingView()
+                        .transition(.opacity)
+                }
             }
 
             if isLoading {


### PR DESCRIPTION
## Summary
Adds a 4-page onboarding tutorial for first-time users to introduce Taskweave's key features and request necessary permissions.

**Onboarding Flow:**
1. **Welcome** - App introduction with branded icon
2. **Calendar Integration** - Highlights task scheduling as time blocks
3. **AI-Powered Suggestions** - Showcases smart recommendations
4. **Permissions** - Requests calendar and notification access

**Implementation:**
- Uses `@AppStorage` to persist onboarding completion state
- Shows only on first launch, skips on subsequent launches
- Skippable at any point via "Skip" button
- Smooth transitions between pages

## Test plan
- [x] Build succeeds
- [x] Onboarding shows on fresh install (simulator)
- [x] Onboarding shows on fresh install (physical device)
- [x] All 4 pages display correctly
- [x] "Get Started" transitions to main app
- [x] Onboarding doesn't show on subsequent launches

Closes #21