### PR TITLE
refactor: Remove duplicate Categories from Settings

### DIFF
--- a/Lazyflow/Sources/Views/SettingsView.swift
+++ b/Lazyflow/Sources/Views/SettingsView.swift
@@ -47,22 +47,6 @@ struct SettingsView: View {
                     }
                 }
 
-                // Categories
-                Section("Categories") {
-                    NavigationLink {
-                        CategoryManagementView()
-                    } label: {
-                        HStack {
-                            Label("Manage Categories", systemImage: "tag")
-                                .foregroundColor(Color.Lazyflow.textPrimary)
-                            Spacer()
-                            Text("\(CategoryService.shared.categories.count) custom")
-                                .font(DesignSystem.Typography.footnote)
-                                .foregroundColor(Color.Lazyflow.textSecondary)
-                        }
-                    }
-                }
-
                 // Notifications
                 Section("Notifications") {
                     Button {


### PR DESCRIPTION
## Summary

Remove duplicate navigation path to Categories.

Before:
- More > Categories
- More > Settings > Categories (duplicate)

After:
- More > Categories (only path)

## Test plan

- [x] Unit tests: 411 passed
- [x] UI tests: 42 passed
- [ ] Verify More > Categories still works
- [ ] Verify Settings no longer shows Categories section

Closes #144