### PR TITLE
fix(ui): Enable scrolling in AddTaskView when keyboard is visible

### DIFF
--- a/Lazyflow/Sources/Views/AddTaskView.swift
+++ b/Lazyflow/Sources/Views/AddTaskView.swift
@@ -56,7 +56,7 @@ struct AddTaskView: View {
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 0) {
+            ScrollView {
                 // Main input area
                 VStack(spacing: DesignSystem.Spacing.md) {
                     // Title field with AI button
@@ -161,9 +161,8 @@ struct AddTaskView: View {
                 }
                 .padding(.bottom, DesignSystem.Spacing.lg)
                 .background(Color.adaptiveSurface)
-
-                Spacer()
             }
+            .scrollDismissesKeyboard(.interactively)
             .background(Color.adaptiveBackground)
             .navigationTitle("New Task")
             .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
## Summary

Fix keyboard covering intraday recurring options in AddTaskView.

## Problem

When adding a new task with intraday recurring (Times Per Day/Hourly),
the active hours and end date options were hidden behind the keyboard
with no way to scroll to see them.

## Solution

- Wrap main content in ScrollView
- Add scrollDismissesKeyboard(.interactively) for better UX

## Test plan

- [ ] Open Add Task, enable Times Per Day recurring
- [ ] Verify you can scroll to see Active Hours and End Date options
- [ ] Verify scrolling down dismisses keyboard interactively