### PR TITLE
test: add UI test for Regenerate AI button

### DIFF
--- a/Lazyflow/Sources/Views/DailySummaryView.swift
+++ b/Lazyflow/Sources/Views/DailySummaryView.swift
@@ -42,6 +42,7 @@ struct DailySummaryView: View {
                 } label: {
                     Image(systemName: "arrow.clockwise")
                 }
+                .accessibilityIdentifier("Refresh Summary")
                 .disabled(isLoading)
 
                 // Show Regenerate AI when summary data exists (even if AI failed previously)
@@ -53,6 +54,7 @@ struct DailySummaryView: View {
                     } label: {
                         Image(systemName: "sparkles")
                     }
+                    .accessibilityIdentifier("Regenerate AI")
                     .disabled(isLoading)
                 }
             }

--- a/Lazyflow/Sources/Views/MorningBriefingView.swift
+++ b/Lazyflow/Sources/Views/MorningBriefingView.swift
@@ -42,6 +42,7 @@ struct MorningBriefingView: View {
                 } label: {
                     Image(systemName: "arrow.clockwise")
                 }
+                .accessibilityIdentifier("Refresh Briefing")
                 .disabled(isLoading)
 
                 // Show Regenerate AI when briefing data exists (even if AI failed previously)
@@ -53,6 +54,7 @@ struct MorningBriefingView: View {
                     } label: {
                         Image(systemName: "sparkles")
                     }
+                    .accessibilityIdentifier("Regenerate AI")
                     .disabled(isLoading)
                 }
             }

--- a/LazyflowUITests/LazyflowUITests.swift
+++ b/LazyflowUITests/LazyflowUITests.swift
@@ -734,31 +734,35 @@ final class LazyflowUITests: XCTestCase {
     func testMorningBriefingRegenerateAI() throws {
         navigateToToday()
 
+        // Morning Briefing card is time-dependent (only shows in morning hours)
         let briefingCard = app.staticTexts.matching(NSPredicate(format: "label CONTAINS[c] 'Start Your Day'")).firstMatch
-        if briefingCard.waitForExistence(timeout: 2) && briefingCard.isHittable {
-            briefingCard.tap()
+        guard briefingCard.waitForExistence(timeout: 2) && briefingCard.isHittable else {
+            throw XCTSkip("Morning Briefing card not available (only shows in morning hours)")
+        }
 
-            // Wait for briefing view
-            let briefingNav = app.navigationBars["Good Morning"]
-            XCTAssertTrue(briefingNav.waitForExistence(timeout: 3))
+        briefingCard.tap()
 
-            // Find regenerate AI button (sparkles icon)
-            let regenerateButton = app.buttons.matching(NSPredicate(format: "identifier CONTAINS[c] 'sparkles'")).firstMatch
-            if regenerateButton.waitForExistence(timeout: 2) && regenerateButton.isHittable {
-                regenerateButton.tap()
+        // Wait for briefing view
+        let briefingNav = app.navigationBars["Good Morning"]
+        XCTAssertTrue(briefingNav.waitForExistence(timeout: 3), "Morning Briefing view should open")
 
-                // Wait for regeneration to complete
-                sleep(2)
+        // Find regenerate AI button using accessibility identifier
+        let regenerateButton = app.buttons["Regenerate AI"]
+        XCTAssertTrue(regenerateButton.waitForExistence(timeout: 3), "Regenerate AI button should exist when briefing has data")
 
-                // View should still exist after regenerate
-                XCTAssertTrue(briefingNav.exists)
-            }
+        // Tap regenerate button
+        regenerateButton.tap()
 
-            // Dismiss
-            let doneButton = app.buttons["Done"]
-            if doneButton.exists {
-                doneButton.tap()
-            }
+        // Wait for regeneration to complete
+        sleep(2)
+
+        // View should still exist after regenerate
+        XCTAssertTrue(briefingNav.exists, "View should remain stable after regeneration")
+
+        // Dismiss
+        let doneButton = app.buttons["Done"]
+        if doneButton.exists {
+            doneButton.tap()
         }
     }
 


### PR DESCRIPTION
## Summary
Add UI test for the Regenerate AI button with proper accessibility identifiers.

## Changes
- Add `accessibilityIdentifier("Regenerate AI")` to sparkles buttons in both views
- Add `accessibilityIdentifier("Refresh Briefing/Summary")` to refresh buttons
- Update UI test to use explicit identifier instead of partial string match
- Use `XCTSkip` with clear message when Morning Briefing card unavailable (time-dependent)
- Add explicit assertions that fail when expected elements not found

## Fixes from Review
- No longer silently passes - skips explicitly when card unavailable
- Uses reliable accessibility identifier instead of partial match

## Test Results

### Unit Tests
| Device | Tests | Passed | Failed |
|--------|-------|--------|--------|
| iPhone 17 Pro | 589 | 589 | 0 |

### UI Tests
| Device | Tests | Passed | Skipped | Failed |
|--------|-------|--------|---------|--------|
| iPhone 17 Pro | 18 | 17 | 1 | 0 |
| iPad Pro 13-inch (M5) | 38 | 34 | 4 | 0 |

Note: Morning Briefing tests skip outside morning hours (time-dependent).

## Related
- Follow-up to #164