### PR TITLE
fix(ui): add adaptive background to Calendar tab

### DIFF
--- a/Lazyflow/Sources/Views/CalendarView.swift
+++ b/Lazyflow/Sources/Views/CalendarView.swift
@@ -163,6 +163,7 @@ struct CalendarView: View {
                 // Undo: delete the created task
                 taskService.deleteTask(action.task)
             }
+            .background(Color.adaptiveBackground)
     }
 
     // MARK: - Sheets Modifier


### PR DESCRIPTION
## Summary
- Add missing `Color.adaptiveBackground` to Calendar tab's `calendarContent`, matching all other tabs

Closes #193

## Test plan
- [ ] Open Calendar tab in light mode — background matches other tabs
- [ ] Open Calendar tab in dark mode — background matches other tabs