### PR TITLE
feat(summary): add carryover section to Daily Summary

### DIFF
--- a/Lazyflow.xcodeproj/project.pbxproj
+++ b/Lazyflow.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		514462FECCB375A2E0CDECF6 /* TodayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A8720AD9E15D86484861BD /* TodayView.swift */; };
 		546AB39771158C72F79E1DB2 /* TimeProtectionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A581B0280BBAEC4334B6BA /* TimeProtectionServiceTests.swift */; };
 		5576D58CCF1EE6F3D152EB91 /* AIQualityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97AF479F9F479C7F6AD24212 /* AIQualityView.swift */; };
+		55D043F6F8063A39FF708981 /* DailySummaryCarryoverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F44E5FAD747B2345B46B51A /* DailySummaryCarryoverTests.swift */; };
 		5740486A0D5FC08A3D6216C6 /* AIQualityViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9732C67059BB87D362CA70F /* AIQualityViewModel.swift */; };
 		584AEAA632B8FBA89C12CCFF /* ListsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3391545EB6E7A4277AF8D35 /* ListsView.swift */; };
 		59458963ACA0ED5B8963E1B1 /* LazyflowComplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500B294690B749F58C76D79 /* LazyflowComplication.swift */; };
@@ -264,6 +265,7 @@
 		55CAA946FCF526BB2AFEAE68 /* TaskViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskViewModelTests.swift; sourceTree = "<group>"; };
 		5760FDBBA61D5FF9EB511AF0 /* CustomCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCategory.swift; sourceTree = "<group>"; };
 		5F018E899F22FF4A0E0F8001 /* RecurringRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecurringRule.swift; sourceTree = "<group>"; };
+		5F44E5FAD747B2345B46B51A /* DailySummaryCarryoverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailySummaryCarryoverTests.swift; sourceTree = "<group>"; };
 		5FD94A2D660B93F6C3A2DB8A /* LazyflowShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyflowShortcuts.swift; sourceTree = "<group>"; };
 		61EC4AC29B50F17794EC5BF7 /* MorningBriefingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MorningBriefingView.swift; sourceTree = "<group>"; };
 		63AE12B89929F764DCED4335 /* SubtaskProgressBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubtaskProgressBadge.swift; sourceTree = "<group>"; };
@@ -479,6 +481,7 @@
 				536D6481AFECBC651BA4CF75 /* AnalyticsServiceTests.swift */,
 				F1B80002E148BF3F059F003E /* CategoryServiceTests.swift */,
 				79878ECB4B8D1E2274BF2E3E /* ConflictDetectionServiceTests.swift */,
+				5F44E5FAD747B2345B46B51A /* DailySummaryCarryoverTests.swift */,
 				F65D128C9CC4A66B9423CDF0 /* DailySummaryServiceTests.swift */,
 				68FC02D90A38A01F152672E3 /* EventPreferenceLearningServiceTests.swift */,
 				4682DC1EE1661DFC28274E38 /* HistoryViewModelTests.swift */,
@@ -959,6 +962,7 @@
 				10D9CF34CB611CE4597D93E5 /* AnalyticsServiceTests.swift in Sources */,
 				E2348389624C78DAE63B632F /* CategoryServiceTests.swift in Sources */,
 				00FCF99113DE7C7D45EE56E3 /* ConflictDetectionServiceTests.swift in Sources */,
+				55D043F6F8063A39FF708981 /* DailySummaryCarryoverTests.swift in Sources */,
 				84B9FAA6C2AA0387D83D18B1 /* DailySummaryServiceTests.swift in Sources */,
 				9C48711EFBD089B3EBAEB7C0 /* EventPreferenceLearningServiceTests.swift in Sources */,
 				A1920639E96CE06499173246 /* HistoryViewModelTests.swift in Sources */,

--- a/Lazyflow/Sources/Views/DailySummaryView.swift
+++ b/Lazyflow/Sources/Views/DailySummaryView.swift
@@ -119,6 +119,11 @@ struct DailySummaryView: View {
                 encouragementCard(encouragement)
             }
 
+            // Carryover Section
+            if summary.hasCarryover {
+                carryoverSection(summary)
+            }
+
             // Completed Tasks
             if !summary.completedTasks.isEmpty {
                 completedTasksSection(summary.completedTasks)
@@ -259,6 +264,76 @@ struct DailySummaryView: View {
         }
         .padding()
         .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.adaptiveSurface)
+        .cornerRadius(DesignSystem.CornerRadius.large)
+    }
+
+    // MARK: - Carryover Section
+
+    private func carryoverSection(_ summary: DailySummaryData) -> some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+            HStack {
+                Image(systemName: "arrow.uturn.forward.circle.fill")
+                    .foregroundColor(Color.Lazyflow.warning)
+                Text("Carryover")
+                    .font(DesignSystem.Typography.headline)
+                    .foregroundColor(Color.Lazyflow.textPrimary)
+                Spacer()
+                Text("\(summary.carryoverTasks.count)")
+                    .font(DesignSystem.Typography.subheadline)
+                    .foregroundColor(Color.Lazyflow.textSecondary)
+            }
+
+            if !summary.suggestedPriorities.isEmpty {
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
+                    Text("Tomorrow's priorities:")
+                        .font(DesignSystem.Typography.caption1)
+                        .foregroundColor(Color.Lazyflow.textSecondary)
+                    ForEach(Array(summary.suggestedPriorities.enumerated()), id: \.offset) { index, title in
+                        HStack(spacing: DesignSystem.Spacing.sm) {
+                            Text("\(index + 1).")
+                                .font(DesignSystem.Typography.subheadline)
+                                .foregroundColor(Color.Lazyflow.accent)
+                                .fontWeight(.semibold)
+                            Text(title)
+                                .font(DesignSystem.Typography.subheadline)
+                                .foregroundColor(Color.Lazyflow.textPrimary)
+                                .lineLimit(1)
+                        }
+                    }
+                }
+                .padding(.bottom, DesignSystem.Spacing.xs)
+            }
+
+            Divider()
+
+            ForEach(summary.carryoverTasks) { task in
+                HStack(spacing: DesignSystem.Spacing.sm) {
+                    Circle()
+                        .fill(task.category.color)
+                        .frame(width: 8, height: 8)
+
+                    Text(task.title)
+                        .font(DesignSystem.Typography.subheadline)
+                        .foregroundColor(Color.Lazyflow.textPrimary)
+                        .lineLimit(1)
+
+                    Spacer()
+
+                    if task.isOverdue {
+                        Text("Overdue")
+                            .font(DesignSystem.Typography.caption2)
+                            .foregroundColor(Color.Lazyflow.error)
+                    }
+
+                    Image(systemName: task.priority.iconName)
+                        .font(.system(size: 12))
+                        .foregroundColor(task.priority.color)
+                }
+                .padding(.vertical, DesignSystem.Spacing.xs)
+            }
+        }
+        .padding()
         .background(Color.adaptiveSurface)
         .cornerRadius(DesignSystem.CornerRadius.large)
     }

--- a/LazyflowTests/DailySummaryCarryoverTests.swift
+++ b/LazyflowTests/DailySummaryCarryoverTests.swift
@@ -1,0 +1,176 @@
+import XCTest
+@testable import Lazyflow
+
+@MainActor
+final class DailySummaryCarryoverTests: XCTestCase {
+    var persistenceController: PersistenceController!
+    var taskService: TaskService!
+    var dailySummaryService: DailySummaryService!
+
+    override func setUpWithError() throws {
+        persistenceController = PersistenceController(inMemory: true)
+        taskService = TaskService(persistenceController: persistenceController)
+        dailySummaryService = DailySummaryService(taskService: taskService, llmService: .shared)
+
+        UserDefaults.standard.removeObject(forKey: "daily_summary_history")
+        UserDefaults.standard.removeObject(forKey: "last_summary_date")
+        UserDefaults.standard.removeObject(forKey: "streak_data")
+    }
+
+    override func tearDownWithError() throws {
+        persistenceController.deleteAllDataEverywhere()
+        persistenceController = nil
+        taskService = nil
+        dailySummaryService = nil
+
+        UserDefaults.standard.removeObject(forKey: "daily_summary_history")
+        UserDefaults.standard.removeObject(forKey: "last_summary_date")
+        UserDefaults.standard.removeObject(forKey: "streak_data")
+    }
+
+    // MARK: - Carryover Tasks
+
+    func testCarryover_NoUnfinishedTasks_EmptyCarryover() async throws {
+        // Create and complete a task due today
+        let task = taskService.createTask(title: "Done Task", dueDate: Date())
+        taskService.toggleTaskCompletion(task)
+
+        let summary = await dailySummaryService.generateSummary(for: Date(), persist: false)
+        XCTAssertTrue(summary.carryoverTasks.isEmpty)
+    }
+
+    func testCarryover_UnfinishedTodayTask_IncludedInCarryover() async throws {
+        // Create an incomplete task due today
+        _ = taskService.createTask(title: "Unfinished Task", dueDate: Date())
+
+        let summary = await dailySummaryService.generateSummary(for: Date(), persist: false)
+        XCTAssertEqual(summary.carryoverTasks.count, 1)
+        XCTAssertEqual(summary.carryoverTasks.first?.title, "Unfinished Task")
+    }
+
+    func testCarryover_OverdueTask_IncludedInCarryover() async throws {
+        // Create an incomplete task due yesterday
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        _ = taskService.createTask(title: "Overdue Task", dueDate: yesterday)
+
+        let summary = await dailySummaryService.generateSummary(for: Date(), persist: false)
+        XCTAssertEqual(summary.carryoverTasks.count, 1)
+        XCTAssertEqual(summary.carryoverTasks.first?.title, "Overdue Task")
+        XCTAssertTrue(summary.carryoverTasks.first?.isOverdue ?? false)
+    }
+
+    func testCarryover_CompletedTasks_NotIncluded() async throws {
+        // Create two tasks: one completed, one not
+        let task1 = taskService.createTask(title: "Completed Task", dueDate: Date())
+        taskService.toggleTaskCompletion(task1)
+        _ = taskService.createTask(title: "Still Pending", dueDate: Date())
+
+        let summary = await dailySummaryService.generateSummary(for: Date(), persist: false)
+        XCTAssertEqual(summary.carryoverTasks.count, 1)
+        XCTAssertEqual(summary.carryoverTasks.first?.title, "Still Pending")
+    }
+
+    func testCarryover_MixedTodayAndOverdue() async throws {
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        _ = taskService.createTask(title: "Overdue", dueDate: yesterday)
+        _ = taskService.createTask(title: "Today Pending", dueDate: Date())
+
+        let summary = await dailySummaryService.generateSummary(for: Date(), persist: false)
+        XCTAssertEqual(summary.carryoverTasks.count, 2)
+    }
+
+    func testCarryover_MaxLimit_CapsAt10() async throws {
+        // Create 15 incomplete tasks due today
+        for i in 1...15 {
+            _ = taskService.createTask(title: "Task \(i)", dueDate: Date())
+        }
+
+        let summary = await dailySummaryService.generateSummary(for: Date(), persist: false)
+        XCTAssertEqual(summary.carryoverTasks.count, 10)
+    }
+
+    func testCarryover_SortedByPriority() async throws {
+        _ = taskService.createTask(title: "Low Task", dueDate: Date(), priority: .low)
+        _ = taskService.createTask(title: "Urgent Task", dueDate: Date(), priority: .urgent)
+        _ = taskService.createTask(title: "High Task", dueDate: Date(), priority: .high)
+
+        let summary = await dailySummaryService.generateSummary(for: Date(), persist: false)
+        XCTAssertEqual(summary.carryoverTasks.count, 3)
+        // Sorted by priority descending: urgent, high, low
+        XCTAssertEqual(summary.carryoverTasks[0].title, "Urgent Task")
+        XCTAssertEqual(summary.carryoverTasks[1].title, "High Task")
+        XCTAssertEqual(summary.carryoverTasks[2].title, "Low Task")
+    }
+
+    // MARK: - Suggested Priorities
+
+    func testSuggestedPriorities_NoCarryover_Empty() async throws {
+        let task = taskService.createTask(title: "Done Task", dueDate: Date())
+        taskService.toggleTaskCompletion(task)
+
+        let summary = await dailySummaryService.generateSummary(for: Date(), persist: false)
+        XCTAssertTrue(summary.suggestedPriorities.isEmpty)
+    }
+
+    func testSuggestedPriorities_MaxThree() async throws {
+        // Create 5 incomplete tasks with various priorities
+        _ = taskService.createTask(title: "Urgent 1", dueDate: Date(), priority: .urgent)
+        _ = taskService.createTask(title: "High 1", dueDate: Date(), priority: .high)
+        _ = taskService.createTask(title: "High 2", dueDate: Date(), priority: .high)
+        _ = taskService.createTask(title: "Medium 1", dueDate: Date(), priority: .medium)
+        _ = taskService.createTask(title: "Low 1", dueDate: Date(), priority: .low)
+
+        let summary = await dailySummaryService.generateSummary(for: Date(), persist: false)
+        XCTAssertEqual(summary.suggestedPriorities.count, 3)
+    }
+
+    func testSuggestedPriorities_HighestPriorityFirst() async throws {
+        _ = taskService.createTask(title: "Low Task", dueDate: Date(), priority: .low)
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        _ = taskService.createTask(title: "Overdue High", dueDate: yesterday, priority: .high)
+
+        let summary = await dailySummaryService.generateSummary(for: Date(), persist: false)
+        XCTAssertEqual(summary.suggestedPriorities.first, "Overdue High")
+    }
+
+    // MARK: - hasCarryover
+
+    func testHasCarryover_True_WhenUnfinishedExist() async throws {
+        _ = taskService.createTask(title: "Pending", dueDate: Date())
+
+        let summary = await dailySummaryService.generateSummary(for: Date(), persist: false)
+        XCTAssertTrue(summary.hasCarryover)
+    }
+
+    func testHasCarryover_False_WhenAllCompleted() async throws {
+        let task = taskService.createTask(title: "Done", dueDate: Date())
+        taskService.toggleTaskCompletion(task)
+
+        let summary = await dailySummaryService.generateSummary(for: Date(), persist: false)
+        XCTAssertFalse(summary.hasCarryover)
+    }
+
+    // MARK: - Codable Backward Compatibility
+
+    func testCodable_LegacyPayload_DecodesWithEmptyCarryover() throws {
+        // Simulate a pre-carryover persisted summary (no carryoverTasks/suggestedPriorities keys)
+        let legacyJSON = """
+        {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "date": 0,
+            "tasksCompleted": 3,
+            "totalTasksPlanned": 5,
+            "completedTasks": [],
+            "topCategory": 1,
+            "totalMinutesWorked": 120,
+            "productivityScore": 60.0,
+            "createdAt": 0
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(DailySummaryData.self, from: legacyJSON)
+        XCTAssertTrue(decoded.carryoverTasks.isEmpty)
+        XCTAssertTrue(decoded.suggestedPriorities.isEmpty)
+        XCTAssertEqual(decoded.tasksCompleted, 3)
+    }
+}


### PR DESCRIPTION
## Summary
- Add carryover section to Daily Summary showing unfinished and overdue tasks
- Show top 3 suggested priorities for tomorrow based on task priority
- Include backward-compatible Codable decoding for existing persisted summaries
- 13 unit tests covering carryover logic, priority sorting, limits, and Codable migration

Closes #171

## Test plan
- [x] 13 unit tests pass (carryover tasks, suggested priorities, hasCarryover flag, Codable backward compatibility)
- [x] Full test suite (740+ tests) passes
- [x] Build succeeds on iOS Simulator
- [x] Codex peer review: ship-with-known-risks (0 critical, 2 acknowledged warnings)