### PR TITLE
chore(summary): remove backward-compatible Codable decoder

### DIFF
--- a/Lazyflow/Sources/Models/DailySummaryData.swift
+++ b/Lazyflow/Sources/Models/DailySummaryData.swift
@@ -50,24 +50,6 @@ struct DailySummaryData: Codable, Identifiable {
         self.createdAt = createdAt
     }
 
-    // Custom decoder for backward compatibility with persisted summaries
-    // that don't have carryoverTasks/suggestedPriorities keys
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        id = try container.decode(UUID.self, forKey: .id)
-        date = try container.decode(Date.self, forKey: .date)
-        tasksCompleted = try container.decode(Int.self, forKey: .tasksCompleted)
-        totalTasksPlanned = try container.decode(Int.self, forKey: .totalTasksPlanned)
-        completedTasks = try container.decode([CompletedTaskSummary].self, forKey: .completedTasks)
-        topCategory = try container.decodeIfPresent(TaskCategory.self, forKey: .topCategory)
-        totalMinutesWorked = try container.decode(Int.self, forKey: .totalMinutesWorked)
-        productivityScore = try container.decode(Double.self, forKey: .productivityScore)
-        aiSummary = try container.decodeIfPresent(String.self, forKey: .aiSummary)
-        encouragement = try container.decodeIfPresent(String.self, forKey: .encouragement)
-        createdAt = try container.decode(Date.self, forKey: .createdAt)
-        carryoverTasks = try container.decodeIfPresent([CarryoverTaskSummary].self, forKey: .carryoverTasks) ?? []
-        suggestedPriorities = try container.decodeIfPresent([String].self, forKey: .suggestedPriorities) ?? []
-    }
 
     /// Completion percentage (0-100)
     var completionPercentage: Int {

--- a/LazyflowTests/DailySummaryCarryoverTests.swift
+++ b/LazyflowTests/DailySummaryCarryoverTests.swift
@@ -150,27 +150,4 @@ final class DailySummaryCarryoverTests: XCTestCase {
         XCTAssertFalse(summary.hasCarryover)
     }
 
-    // MARK: - Codable Backward Compatibility
-
-    func testCodable_LegacyPayload_DecodesWithEmptyCarryover() throws {
-        // Simulate a pre-carryover persisted summary (no carryoverTasks/suggestedPriorities keys)
-        let legacyJSON = """
-        {
-            "id": "00000000-0000-0000-0000-000000000001",
-            "date": 0,
-            "tasksCompleted": 3,
-            "totalTasksPlanned": 5,
-            "completedTasks": [],
-            "topCategory": 1,
-            "totalMinutesWorked": 120,
-            "productivityScore": 60.0,
-            "createdAt": 0
-        }
-        """.data(using: .utf8)!
-
-        let decoded = try JSONDecoder().decode(DailySummaryData.self, from: legacyJSON)
-        XCTAssertTrue(decoded.carryoverTasks.isEmpty)
-        XCTAssertTrue(decoded.suggestedPriorities.isEmpty)
-        XCTAssertEqual(decoded.tasksCompleted, 3)
-    }
 }


### PR DESCRIPTION
## Summary
- Remove custom `init(from decoder:)` from `DailySummaryData`
- Remove legacy payload regression test
- Not needed since carryover fields ship in the same release as the model change — no persisted data exists without the new keys

## Test plan
- [x] Build succeeds
- [x] 12 remaining carryover tests unaffected