### PR TITLE
chore(taskrow): polish task item UI with metadata and styling improvements

### DIFF
--- a/Lazyflow/Sources/Services/AnalyticsService.swift
+++ b/Lazyflow/Sources/Services/AnalyticsService.swift
@@ -16,7 +16,7 @@ class AnalyticsService: ObservableObject {
 
     init(
         taskService: TaskService = .shared,
-        taskListService: TaskListService = TaskListService(),
+        taskListService: TaskListService = .shared,
         categoryService: CategoryService = .shared
     ) {
         self.taskService = taskService

--- a/Lazyflow/Sources/Services/TaskListService.swift
+++ b/Lazyflow/Sources/Services/TaskListService.swift
@@ -4,6 +4,8 @@ import Combine
 
 /// Service responsible for all TaskList-related CRUD operations
 final class TaskListService: ObservableObject {
+    static let shared = TaskListService()
+
     private let persistenceController: PersistenceController
 
     @Published private(set) var lists: [TaskList] = []

--- a/Lazyflow/Sources/Utilities/DesignSystem.swift
+++ b/Lazyflow/Sources/Utilities/DesignSystem.swift
@@ -199,6 +199,19 @@ struct PriorityBadge: View {
 struct DueDateBadge: View {
     let date: Date
     let isOverdue: Bool
+    var isDueToday: Bool = false
+
+    private var foregroundColor: Color {
+        if isOverdue { return Color.Lazyflow.error }
+        if isDueToday { return Color.Lazyflow.accent }
+        return Color.Lazyflow.textTertiary
+    }
+
+    private var backgroundColor: Color {
+        if isOverdue { return Color.Lazyflow.error.opacity(0.15) }
+        if isDueToday { return Color.Lazyflow.accent.opacity(0.12) }
+        return Color.secondary.opacity(0.1)
+    }
 
     var body: some View {
         HStack(spacing: 4) {
@@ -208,14 +221,10 @@ struct DueDateBadge: View {
                 .font(DesignSystem.Typography.caption2)
                 .lineLimit(1)
         }
-        .foregroundColor(isOverdue ? Color.Lazyflow.error : Color.Lazyflow.textTertiary)
+        .foregroundColor(foregroundColor)
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
-        .background(
-            isOverdue
-                ? Color.Lazyflow.error.opacity(0.15)
-                : Color.secondary.opacity(0.1)
-        )
+        .background(backgroundColor)
         .cornerRadius(DesignSystem.CornerRadius.small)
         .fixedSize()
         .accessibilityHidden(true) // Info conveyed via parent row label
@@ -241,6 +250,37 @@ struct CategoryBadge: View {
             .cornerRadius(DesignSystem.CornerRadius.small)
             .fixedSize()
             .accessibilityHidden(true) // Info conveyed via parent row label
+        }
+    }
+}
+
+struct TaskCategoryBadge: View {
+    let systemCategory: TaskCategory
+    var customCategoryID: UUID?
+    var isCompleted: Bool = false
+
+    private var display: (name: String, color: Color, iconName: String) {
+        CategoryService.shared.getCategoryDisplay(systemCategory: systemCategory, customCategoryID: customCategoryID)
+    }
+
+    /// True when a real category exists (handles stale customCategoryID gracefully)
+    private var hasCategory: Bool {
+        let info = display
+        // If customCategoryID is dangling (deleted), getCategoryDisplay falls back to system.
+        // Only show badge when there's a meaningful category.
+        if let _ = customCategoryID {
+            return info.name != TaskCategory.uncategorized.displayName
+        }
+        return systemCategory != .uncategorized
+    }
+
+    var body: some View {
+        if hasCategory {
+            Image(systemName: display.iconName)
+                .font(.caption2)
+                .foregroundColor(display.color)
+                .opacity(isCompleted ? 0.5 : 1.0)
+                .accessibilityHidden(true)
         }
     }
 }

--- a/Lazyflow/Sources/ViewModels/ListsViewModel.swift
+++ b/Lazyflow/Sources/ViewModels/ListsViewModel.swift
@@ -20,7 +20,7 @@ final class ListsViewModel: ObservableObject {
     private let taskService: TaskService
     private var cancellables = Set<AnyCancellable>()
 
-    init(taskListService: TaskListService = TaskListService(), taskService: TaskService = TaskService()) {
+    init(taskListService: TaskListService = .shared, taskService: TaskService = TaskService()) {
         self.taskListService = taskListService
         self.taskService = taskService
         setupBindings()

--- a/Lazyflow/Sources/Views/AddTaskView.swift
+++ b/Lazyflow/Sources/Views/AddTaskView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct AddTaskView: View {
     @Environment(\.dismiss) private var dismiss
     @StateObject private var viewModel: TaskViewModel
-    @StateObject private var listService = TaskListService()
+    @StateObject private var listService = TaskListService.shared
     @StateObject private var categoryService = CategoryService.shared
     @StateObject private var llmService = LLMService.shared
     @FocusState private var isTitleFocused: Bool

--- a/Lazyflow/Sources/Views/ExpandableTaskRowView.swift
+++ b/Lazyflow/Sources/Views/ExpandableTaskRowView.swift
@@ -20,6 +20,8 @@ struct ExpandableTaskRowView: View {
     var onSubtaskDelete: ((Task) -> Void)?
     var onSubtaskPromote: ((Task) -> Void)?
     var onAddSubtask: ((Task) -> Void)?
+    var showListIndicator: Bool = false
+    var listColorHex: String? = nil
 
     @State private var isExpanded: Bool = true
     @State private var isPressed = false
@@ -44,7 +46,9 @@ struct ExpandableTaskRowView: View {
                 onStartWorking: onStartWorking,
                 onStopWorking: onStopWorking,
                 hideSubtaskBadge: true,
-                showProgressRing: task.hasSubtasks
+                showProgressRing: task.hasSubtasks,
+                showListIndicator: showListIndicator,
+                listColorHex: listColorHex
             )
 
             // Subtasks section

--- a/Lazyflow/Sources/Views/ListDetailView.swift
+++ b/Lazyflow/Sources/Views/ListDetailView.swift
@@ -193,7 +193,7 @@ struct ListDetailView: View {
 
 struct EditListSheet: View {
     @Environment(\.dismiss) private var dismiss
-    @StateObject private var listService = TaskListService()
+    @StateObject private var listService = TaskListService.shared
 
     let list: TaskList
 

--- a/Lazyflow/Sources/Views/SubtaskRowView.swift
+++ b/Lazyflow/Sources/Views/SubtaskRowView.swift
@@ -39,7 +39,7 @@ struct SubtaskRowView: View {
             Button {
                 onTap()
             } label: {
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.xxs) {
                     // Title
                     Text(subtask.title)
                         .font(DesignSystem.Typography.subheadline)

--- a/Lazyflow/Sources/Views/TaskDetailView.swift
+++ b/Lazyflow/Sources/Views/TaskDetailView.swift
@@ -6,7 +6,7 @@ struct TaskDetailView: View {
     @StateObject private var viewModel: TaskViewModel
     @StateObject private var llmService = LLMService.shared
     @StateObject private var taskService = TaskService.shared
-    @StateObject private var listService = TaskListService()
+    @StateObject private var listService = TaskListService.shared
     @StateObject private var categoryService = CategoryService.shared
     @FocusState private var isTitleFocused: Bool
 

--- a/Lazyflow/Sources/Views/TodayView.swift
+++ b/Lazyflow/Sources/Views/TodayView.swift
@@ -22,6 +22,7 @@ struct TodayView: View {
     @State private var showAutoCompleteCelebration = false
     @State private var autoCompletedParentTitle = ""
     @StateObject private var summaryService = DailySummaryService.shared
+    @StateObject private var listService = TaskListService.shared
     @AppStorage("summaryPromptHour") private var summaryPromptHour: Int = 18
     @AppStorage("morningBriefingEnabled") private var morningBriefingEnabled: Bool = true
     @AppStorage("lastMorningBriefingDate") private var lastMorningBriefingDate: Double = 0
@@ -263,6 +264,13 @@ struct TodayView: View {
     private func applyBatchReschedule(_ batchSuggestion: BatchRescheduleSuggestion) {
         _ = rescheduleService.applyBatchReschedule(batch: batchSuggestion, taskService: TaskService.shared)
         scanForConflicts()
+    }
+
+    private func listColorHex(for task: Task) -> String? {
+        guard let listID = task.listID,
+              let list = listService.getList(byID: listID),
+              !list.isDefault else { return nil }
+        return list.colorHex
     }
 
     private func pushToTomorrow(_ task: Task) {
@@ -524,7 +532,9 @@ struct TodayView: View {
             onStartWorking: isCompleted ? nil : { viewModel.startWorking(on: $0) },
             onStopWorking: isCompleted ? nil : { viewModel.stopWorking(on: $0) },
             hideSubtaskBadge: true,
-            showProgressRing: task.hasSubtasks
+            showProgressRing: task.hasSubtasks,
+            showListIndicator: true,
+            listColorHex: listColorHex(for: task)
         )
         .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: task.hasSubtasks ? 0 : 4, trailing: 16))
 

--- a/Lazyflow/Sources/Views/UpcomingView.swift
+++ b/Lazyflow/Sources/Views/UpcomingView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct UpcomingView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @StateObject private var taskService = TaskService.shared
+    @StateObject private var listService = TaskListService.shared
     @State private var selectedTask: Task?
     @State private var showAddTask = false
     @State private var taskToSchedule: Task?
@@ -136,7 +137,9 @@ struct UpcomingView: View {
                             onDueDateChange: { updateTaskDueDate($0, dueDate: $1) },
                             onDelete: { taskService.deleteTask($0) },
                             onStartWorking: { taskService.startWorking(on: $0) },
-                            onStopWorking: { taskService.stopWorking(on: $0) }
+                            onStopWorking: { taskService.stopWorking(on: $0) },
+                            showListIndicator: true,
+                            listColorHex: listColorHex(for: task)
                         )
                         .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
                         .listRowBackground(Color.adaptiveBackground)
@@ -162,7 +165,9 @@ struct UpcomingView: View {
                             onDueDateChange: { updateTaskDueDate($0, dueDate: $1) },
                             onDelete: { taskService.deleteTask($0) },
                             onStartWorking: { taskService.startWorking(on: $0) },
-                            onStopWorking: { taskService.stopWorking(on: $0) }
+                            onStopWorking: { taskService.stopWorking(on: $0) },
+                            showListIndicator: true,
+                            listColorHex: listColorHex(for: task)
                         )
                         .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
                         .listRowBackground(Color.adaptiveBackground)
@@ -237,6 +242,13 @@ struct UpcomingView: View {
         var updatedTask = task
         updatedTask.dueDate = dueDate
         taskService.updateTask(updatedTask)
+    }
+
+    private func listColorHex(for task: Task) -> String? {
+        guard let listID = task.listID,
+              let list = listService.getList(byID: listID),
+              !list.isDefault else { return nil }
+        return list.colorHex
     }
 
     private func pushToTomorrow(_ task: Task) {


### PR DESCRIPTION
## Summary
- Add **due-today** state to `DueDateBadge` (teal accent color + background)
- New **icon-only `TaskCategoryBadge`** supporting custom categories, visible even for completed tasks (dimmed at 50% opacity)
- **Overdue row background tint** (error color at 4% opacity) for subtle visual emphasis
- **List color dot** indicator in metadata row (opt-in via `showListIndicator`, enabled in TodayView and UpcomingView)
- **Recurring indicator** moved from standalone right-aligned position into metadata row (10pt, inline with other badges)
- **Notes indicator** guard against empty strings, slightly larger (11pt) and more visible (`textSecondary`)
- **Completed task opacity** (0.75) on inner content while keeping background at full opacity
- **`hasMetadata`** refactored into named intermediate booleans for readability
- **VoiceOver** accessibility label now announces custom categories, list name, and handles stale customCategoryID
- **SubtaskRowView** spacing tokenized (`2` → `DesignSystem.Spacing.xxs`)
- **`TaskListService.shared`** singleton added to avoid duplicate observer overhead across views
- **Stale `customCategoryID`** guarded in badge rendering, accessibility label, and hasMetadata check

## Files Changed
| File | Changes |
|---|---|
| `DesignSystem.swift` | `isDueToday` on `DueDateBadge`; new `TaskCategoryBadge` with stale-ID guard |
| `TaskRowView.swift` | Overdue tint, due-today badge, category icon-only, list dot, recurring in metadata, notes icon, completed opacity, hasMetadata refactor, accessibility fix (category + list name) |
| `ExpandableTaskRowView.swift` | `showListIndicator` + `listColorHex` passthrough |
| `SubtaskRowView.swift` | Spacing token fix |
| `TodayView.swift` | List indicator enabled, uses `TaskListService.shared` |
| `UpcomingView.swift` | List indicator enabled, uses `TaskListService.shared` |
| `TaskListService.swift` | Added `static let shared` singleton |
| `AnalyticsService.swift` | Default param updated to `.shared` |
| `ListsViewModel.swift` | Default param updated to `.shared` |
| `ListDetailView.swift` | Uses `TaskListService.shared` |
| `AddTaskView.swift` | Uses `TaskListService.shared` |
| `TaskDetailView.swift` | Uses `TaskListService.shared` |

## Test plan
- [x] Build succeeds (clean, no new warnings)
- [x] All unit tests pass
- [x] All UI tests pass
- [x] CI checks pass (build-and-test + ui-tests)
- [x] Codex peer review passed (4 rounds)
- [x] Manual VoiceOver test
- [x] Visual check on simulator

Closes #132