### PR TITLE
Centralize configuration constants and UserDefaults keys

### DIFF
--- a/Lazyflow.xcodeproj/project.pbxproj
+++ b/Lazyflow.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		00FCF99113DE7C7D45EE56E3 /* ConflictDetectionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79878ECB4B8D1E2274BF2E3E /* ConflictDetectionServiceTests.swift */; };
 		02CF13FEBA7C04CCA8AEB9F6 /* UserPatterns.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A98881B182C06832E4A3E81 /* UserPatterns.swift */; };
 		060FCFCAF48C8886212BD282 /* AppIcon.svg in Resources */ = {isa = PBXBuildFile; fileRef = 3C4824B59531F94012837CB8 /* AppIcon.svg */; };
+		06D42174CAC359A97E1B0DC1 /* AppConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494CC5A6CB7F26DB65466B65 /* AppConstants.swift */; };
 		06EDBEB5ECEB18959D52E6B8 /* LazyflowShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD94A2D660B93F6C3A2DB8A /* LazyflowShortcuts.swift */; };
 		06F5CEF222A90606174956F9 /* LLMProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9EA2BF6794DBB1AD8720E5E /* LLMProvider.swift */; };
 		07BE0276CAB5DAE53C44FCF5 /* LockScreenLiveActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2950BA8ACF067780F4117B32 /* LockScreenLiveActivityView.swift */; };
@@ -294,6 +295,7 @@
 		464273955722DB557CDC0BAD /* WidgetTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetTask.swift; sourceTree = "<group>"; };
 		4682DC1EE1661DFC28274E38 /* HistoryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewModelTests.swift; sourceTree = "<group>"; };
 		494953CFA458D3070B16B33F /* TaskCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskCategory.swift; sourceTree = "<group>"; };
+		494CC5A6CB7F26DB65466B65 /* AppConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConstants.swift; sourceTree = "<group>"; };
 		4A8A740277E5A36199E5B8FB /* QuickNotesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickNotesListView.swift; sourceTree = "<group>"; };
 		4AF8442AA52B1DA00F88D2EB /* CalendarSyncServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarSyncServiceTests.swift; sourceTree = "<group>"; };
 		4AFDFDC8E1286CDFF8F8700D /* CategoryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryService.swift; sourceTree = "<group>"; };
@@ -521,6 +523,7 @@
 		515F6C6D1F474C4CD5005AEA /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				494CC5A6CB7F26DB65466B65 /* AppConstants.swift */,
 				EB436CC06BC124AF3305385B /* DesignSystem.swift */,
 			);
 			path = Utilities;
@@ -1139,6 +1142,7 @@
 				F02F3EBA1A0F32A74F609B89 /* AddTaskView.swift in Sources */,
 				DFCC8606539F4F1A7FD457CB /* AnalyticsService.swift in Sources */,
 				5DE526EE168ADDCD8B29EACF /* AnalyticsView.swift in Sources */,
+				06D42174CAC359A97E1B0DC1 /* AppConstants.swift in Sources */,
 				941414731BBE6D9FC45578E5 /* AppleFoundationModelsProvider.swift in Sources */,
 				FFF8F0EDC18C82AEC12885D1 /* AutoCompleteCelebrationView.swift in Sources */,
 				87C660AC81A9DD533F3A6947 /* BehavioralSignals.swift in Sources */,

--- a/Lazyflow/Sources/App/ContentView.swift
+++ b/Lazyflow/Sources/App/ContentView.swift
@@ -6,8 +6,8 @@ import SwiftUI
 /// - iPhone (compact size class): TabView with bottom tabs
 struct ContentView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @AppStorage("appearanceMode") private var appearanceMode: AppearanceMode = .system
-    @AppStorage("hasShownICloudPrompt") private var hasShownICloudPrompt = false
+    @AppStorage(AppConstants.StorageKey.appearanceMode) private var appearanceMode: AppearanceMode = .system
+    @AppStorage(AppConstants.StorageKey.hasShownICloudPrompt) private var hasShownICloudPrompt = false
     @State private var selectedTab: Tab? = .today
     @State private var activeSheet: SheetType?
     @State private var showICloudPrompt = false

--- a/Lazyflow/Sources/Services/AI/AIContextService.swift
+++ b/Lazyflow/Sources/Services/AI/AIContextService.swift
@@ -15,7 +15,7 @@ final class AIContextService: ObservableObject {
 
     // MARK: - Private
 
-    private let recentTasksLimit = 10
+    private let recentTasksLimit = AppConstants.Limits.recentTasksLimit
     private var cancellables = Set<AnyCancellable>()
 
     // MARK: - Initialization

--- a/Lazyflow/Sources/Services/AI/AILearningService.swift
+++ b/Lazyflow/Sources/Services/AI/AILearningService.swift
@@ -30,15 +30,15 @@ struct DurationAccuracy: Codable, Identifiable {
 final class AILearningService: ObservableObject {
     static let shared = AILearningService()
 
-    private let correctionsKey = "aiCorrections"
-    private let durationAccuracyKey = "durationAccuracyData"
-    private let impressionsKey = "aiImpressions"
-    private let refinementsKey = "aiRefinementRequests"
-    private let maxCorrections = 100
-    private let maxAccuracyRecords = 100
-    private let maxImpressions = 200
-    private let maxRefinements = 200
-    private let correctionExpiryDays = 90
+    private let correctionsKey = AppConstants.StorageKey.aiCorrections
+    private let durationAccuracyKey = AppConstants.StorageKey.durationAccuracyData
+    private let impressionsKey = AppConstants.StorageKey.aiImpressions
+    private let refinementsKey = AppConstants.StorageKey.aiRefinementRequests
+    private let maxCorrections = AppConstants.Limits.maxAICorrections
+    private let maxAccuracyRecords = AppConstants.Limits.maxAccuracyRecords
+    private let maxImpressions = AppConstants.Limits.maxAIImpressions
+    private let maxRefinements = AppConstants.Limits.maxAIRefinements
+    private let correctionExpiryDays = AppConstants.Limits.correctionExpiryDays
 
     @Published private(set) var corrections: [AICorrection] = []
     @Published private(set) var durationAccuracyRecords: [DurationAccuracy] = []

--- a/Lazyflow/Sources/Services/AI/EventPreferenceLearningService.swift
+++ b/Lazyflow/Sources/Services/AI/EventPreferenceLearningService.swift
@@ -8,10 +8,10 @@ final class EventPreferenceLearningService: ObservableObject {
 
     // MARK: - Constants
 
-    private let recordsKey = "eventSelectionRecords"
-    private let preferencesKey = "eventTitlePreferences"
-    private let maxRecords = 500
-    private let expiryDays = 180
+    private let recordsKey = AppConstants.StorageKey.eventSelectionRecords
+    private let preferencesKey = AppConstants.StorageKey.eventTitlePreferences
+    private let maxRecords = AppConstants.Limits.maxEventRecords
+    private let expiryDays = AppConstants.Limits.eventExpiryDays
 
     // MARK: - Published State
 

--- a/Lazyflow/Sources/Services/AI/LLM/LLMService.swift
+++ b/Lazyflow/Sources/Services/AI/LLM/LLMService.swift
@@ -14,7 +14,7 @@ final class LLMService: ObservableObject {
         didSet {
             // Only save if provider is available
             if availableProviders.contains(selectedProvider) {
-                UserDefaults.standard.set(selectedProvider.rawValue, forKey: "llm_provider")
+                UserDefaults.standard.set(selectedProvider.rawValue, forKey: AppConstants.StorageKey.llmProvider)
             } else {
                 // Fall back to Apple if selected provider is not available
                 selectedProvider = .apple
@@ -40,7 +40,7 @@ final class LLMService: ObservableObject {
 
     private init() {
         // Load saved provider preference
-        if let savedProvider = UserDefaults.standard.string(forKey: "llm_provider"),
+        if let savedProvider = UserDefaults.standard.string(forKey: AppConstants.StorageKey.llmProvider),
            let providerType = LLMProviderType(rawValue: savedProvider) {
             self.selectedProvider = providerType
         } else {

--- a/Lazyflow/Sources/Services/AI/NoteParsingService.swift
+++ b/Lazyflow/Sources/Services/AI/NoteParsingService.swift
@@ -11,10 +11,10 @@ final class NoteParsingService: ObservableObject {
     private let categoryService = CategoryService.shared
 
     /// Maximum characters sent to LLM
-    private let maxLLMInputLength = 1000
+    private let maxLLMInputLength = AppConstants.Limits.maxLLMInputLength
 
     /// LLM timeout in seconds
-    private let llmTimeout: TimeInterval = 5.0
+    private let llmTimeout: TimeInterval = AppConstants.Timing.llmTimeout
 
     private init() {}
 

--- a/Lazyflow/Sources/Services/AnalyticsService.swift
+++ b/Lazyflow/Sources/Services/AnalyticsService.swift
@@ -268,7 +268,7 @@ class AnalyticsService: ObservableObject {
     }
 
     /// Minimum days of inactivity to consider a list "stale"
-    static let staleThresholdDays = 7
+    static let staleThresholdDays = AppConstants.Limits.staleThresholdDays
 
     /// Detect lists with no activity in 7+ days that have incomplete tasks
     /// Note: Uses fixed threshold regardless of selected period for consistent UX

--- a/Lazyflow/Sources/Services/CalendarService.swift
+++ b/Lazyflow/Sources/Services/CalendarService.swift
@@ -84,7 +84,7 @@ final class CalendarService: ObservableObject {
 
     // MARK: - Lazyflow Calendar
 
-    private static let lazyflowCalendarIDKey = "lazyflowCalendarID"
+    private static let lazyflowCalendarIDKey = AppConstants.StorageKey.lazyflowCalendarID
     private static let lazyflowCalendarTitle = "Lazyflow"
 
     /// Get or create the dedicated Lazyflow calendar for auto-synced events

--- a/Lazyflow/Sources/Services/CalendarSyncService.swift
+++ b/Lazyflow/Sources/Services/CalendarSyncService.swift
@@ -34,16 +34,16 @@ final class CalendarSyncService: ObservableObject {
     // MARK: - Settings Keys
 
     private var isAutoSyncEnabled: Bool {
-        UserDefaults.standard.bool(forKey: "calendarAutoSync")
+        UserDefaults.standard.bool(forKey: AppConstants.StorageKey.calendarAutoSync)
     }
 
     private var completionPolicy: CompletionPolicy {
-        let raw = UserDefaults.standard.string(forKey: "calendarCompletionPolicy") ?? "keep"
+        let raw = UserDefaults.standard.string(forKey: AppConstants.StorageKey.calendarCompletionPolicy) ?? "keep"
         return CompletionPolicy(rawValue: raw) ?? .keepEvent
     }
 
     private var isBusyOnly: Bool {
-        UserDefaults.standard.bool(forKey: "calendarBusyOnly")
+        UserDefaults.standard.bool(forKey: AppConstants.StorageKey.calendarBusyOnly)
     }
 
     // MARK: - Init

--- a/Lazyflow/Sources/Services/DailySummaryService.swift
+++ b/Lazyflow/Sources/Services/DailySummaryService.swift
@@ -35,13 +35,13 @@ final class DailySummaryService: ObservableObject {
 
     // MARK: - Constants
 
-    private let maxContextCharacters = 1500
-    private let minContextQualityThreshold = 0.2
+    private let maxContextCharacters = AppConstants.Limits.maxContextCharacters
+    private let minContextQualityThreshold = AppConstants.Limits.minContextQualityThreshold
 
     // MARK: - UserDefaults Keys
 
-    private static let summaryHistoryKey = "daily_summary_history"
-    private static let lastSummaryDateKey = "last_summary_date"
+    private static let summaryHistoryKey = AppConstants.StorageKey.dailySummaryHistory
+    private static let lastSummaryDateKey = AppConstants.StorageKey.lastSummaryDate
 
     // MARK: - Initialization
 

--- a/Lazyflow/Sources/Services/NotificationService.swift
+++ b/Lazyflow/Sources/Services/NotificationService.swift
@@ -170,7 +170,7 @@ final class NotificationService: @unchecked Sendable {
     // MARK: - Intraday Notifications
 
     /// Maximum notifications per intraday task (to leave budget for other tasks)
-    private static let maxIntradayNotificationsPerTask = 10
+    private static let maxIntradayNotificationsPerTask = AppConstants.Limits.maxIntradayNotificationsPerTask
 
     /// Schedule intraday reminders for a task with an intraday recurring rule
     /// Uses a rolling 24-hour window and respects iOS notification budget

--- a/Lazyflow/Sources/Services/PersistenceController.swift
+++ b/Lazyflow/Sources/Services/PersistenceController.swift
@@ -76,10 +76,10 @@ final class PersistenceController: @unchecked Sendable {
     private static let cloudKitContainerIdentifier = "iCloud.com.lazyflow.app"
 
     /// UserDefaults key for iCloud sync preference
-    private static let iCloudSyncEnabledKey = "iCloudSyncEnabled"
+    private static let iCloudSyncEnabledKey = AppConstants.StorageKey.iCloudSyncEnabled
 
     /// UserDefaults key for last sync date
-    private static let lastSyncDateKey = "lastCloudKitSyncDate"
+    private static let lastSyncDateKey = AppConstants.StorageKey.lastCloudKitSyncDate
 
     // MARK: - iCloud Sync Preference
 
@@ -367,7 +367,7 @@ final class PersistenceController: @unchecked Sendable {
         }
 
         // Wait for store to load (with timeout)
-        let timeout = DispatchTime.now() + .seconds(10)
+        let timeout = DispatchTime.now() + .seconds(Int(AppConstants.Timing.cloudKitTimeout))
         if semaphore.wait(timeout: timeout) == .timedOut {
             print("Warning: Persistent store loading timed out")
         }
@@ -849,8 +849,8 @@ final class PersistenceController: @unchecked Sendable {
             return
         }
 
-        // Delete records in batches of 400 (CloudKit limit)
-        let batchSize = 400
+        // Delete records in batches (CloudKit limit)
+        let batchSize = AppConstants.Limits.batchDeleteSize
         for startIndex in stride(from: 0, to: recordIDs.count, by: batchSize) {
             let endIndex = min(startIndex + batchSize, recordIDs.count)
             let batch = Array(recordIDs[startIndex..<endIndex])

--- a/Lazyflow/Sources/Services/PrioritizationService.swift
+++ b/Lazyflow/Sources/Services/PrioritizationService.swift
@@ -51,8 +51,8 @@ final class PrioritizationService: ObservableObject {
             }
             .store(in: &cancellables)
 
-        // Periodically check for expired snoozes (every 60 seconds)
-        Timer.publish(every: 60, on: .main, in: .common)
+        // Periodically check for expired snoozes
+        Timer.publish(every: AppConstants.Timing.snoozeCheckInterval, on: .main, in: .common)
             .autoconnect()
             .sink { [weak self] _ in
                 self?.refreshExpiredSnoozes()

--- a/Lazyflow/Sources/Services/TaskService.swift
+++ b/Lazyflow/Sources/Services/TaskService.swift
@@ -354,7 +354,7 @@ final class TaskService: ObservableObject {
         // to avoid overwriting busy-only titles and bypassing loop prevention
         if CalendarSyncService.shared.isSyncing { return }
         // When auto-sync is enabled, CalendarSyncService owns the sync lifecycle
-        if UserDefaults.standard.bool(forKey: "calendarAutoSync") { return }
+        if UserDefaults.standard.bool(forKey: AppConstants.StorageKey.calendarAutoSync) { return }
 
         do {
             try calendarService.syncTaskToEvent(task)

--- a/Lazyflow/Sources/Utilities/AppConstants.swift
+++ b/Lazyflow/Sources/Utilities/AppConstants.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+/// Centralized configuration constants for the Lazyflow app.
+/// Prevents magic numbers and string literals scattered across views and services.
+enum AppConstants {
+
+    // MARK: - UserDefaults Keys
+
+    /// Type-safe UserDefaults key names shared across views and services.
+    enum StorageKey {
+        // Appearance & UI
+        static let appearanceMode = "appearanceMode"
+        static let hasSeenOnboarding = "hasSeenOnboarding"
+        static let hasShownICloudPrompt = "hasShownICloudPrompt"
+        static let hapticFeedback = "hapticFeedback"
+        static let showCompletedTasks = "showCompletedTasks"
+
+        // AI Settings
+        static let aiAutoSuggest = "aiAutoSuggest"
+        static let aiEstimateDuration = "aiEstimateDuration"
+        static let aiSuggestPriority = "aiSuggestPriority"
+        static let llmProvider = "llm_provider"
+
+        // Notifications & Scheduling
+        static let defaultReminderTime = "defaultReminderTime"
+        static let summaryPromptHour = "summaryPromptHour"
+        static let morningBriefingEnabled = "morningBriefingEnabled"
+        static let morningBriefingNotificationEnabled = "morningBriefingNotificationEnabled"
+        static let morningBriefingNotificationHour = "morningBriefingNotificationHour"
+        static let dailySummaryNotificationEnabled = "dailySummaryNotificationEnabled"
+        static let dailySummaryNotificationHour = "dailySummaryNotificationHour"
+        static let lastMorningBriefingDate = "lastMorningBriefingDate"
+        static let lastPlanYourDayDate = "lastPlanYourDayDate"
+
+        // Calendar
+        static let calendarViewMode = "calendarViewMode"
+        static let calendarAutoSync = "calendarAutoSync"
+        static let calendarCompletionPolicy = "calendarCompletionPolicy"
+        static let calendarBusyOnly = "calendarBusyOnly"
+        static let autoHideSkippedEvents = "autoHideSkippedEvents"
+
+        // Pomodoro
+        static let pomodoroWorkMinutes = "pomodoroWorkMinutes"
+        static let pomodoroBreakMinutes = "pomodoroBreakMinutes"
+
+        // Focus Session Persistence
+        static let focusSessionTaskID = "focusSessionTaskID"
+        static let focusSessionStartedAt = "focusSessionStartedAt"
+        static let focusSessionIsPaused = "focusSessionIsPaused"
+        static let focusSessionIsOnBreak = "focusSessionIsOnBreak"
+
+        // iCloud Sync
+        static let iCloudSyncEnabled = "iCloudSyncEnabled"
+        static let lastCloudKitSyncDate = "lastCloudKitSyncDate"
+
+        // Calendar Service
+        static let lazyflowCalendarID = "lazyflowCalendarID"
+
+        // AI Learning
+        static let aiCorrections = "aiCorrections"
+        static let durationAccuracyData = "durationAccuracyData"
+        static let aiImpressions = "aiImpressions"
+        static let aiRefinementRequests = "aiRefinementRequests"
+
+        // Event Preference Learning
+        static let eventSelectionRecords = "eventSelectionRecords"
+        static let eventTitlePreferences = "eventTitlePreferences"
+
+        // Daily Summary
+        static let dailySummaryHistory = "daily_summary_history"
+        static let lastSummaryDate = "last_summary_date"
+    }
+
+    // MARK: - Default Values
+
+    /// Default values for user-configurable settings.
+    enum Defaults {
+        static let reminderHour = 9
+        static let summaryPromptHour = 18
+        static let morningBriefingNotificationHour = 7
+        static let dailySummaryNotificationHour = 20
+        static let pomodoroWorkMinutes: Double = 25
+        static let pomodoroBreakMinutes: Double = 5
+        static let activeStartHour = 8
+        static let activeEndHour = 22
+    }
+
+    // MARK: - Service Timeouts
+
+    /// Timeout and debounce intervals for services and UI.
+    enum Timing {
+        static let cloudKitTimeout: TimeInterval = 10
+        static let llmTimeout: TimeInterval = 5
+        static let searchDebounce: TimeInterval = 0.3
+        static let snoozeCheckInterval: TimeInterval = 60
+    }
+
+    // MARK: - Feature Limits
+
+    /// Limits for AI learning, notifications, and batch operations.
+    enum Limits {
+        // AI Learning
+        static let maxAICorrections = 100
+        static let maxAccuracyRecords = 100
+        static let maxAIImpressions = 200
+        static let maxAIRefinements = 200
+        static let correctionExpiryDays = 90
+
+        // Event Preferences
+        static let maxEventRecords = 500
+        static let eventExpiryDays = 180
+
+        // AI Context
+        static let recentTasksLimit = 10
+        static let maxLLMInputLength = 1000
+        static let maxContextCharacters = 1500
+        static let minContextQualityThreshold = 0.2
+        static let maxRecommendationSuggestions = 3
+
+        // Notifications
+        static let maxIntradayNotificationsPerTask = 10
+
+        // Persistence
+        static let batchDeleteSize = 400
+
+        // Analytics
+        static let staleThresholdDays = 7
+    }
+}

--- a/Lazyflow/Sources/ViewModels/FocusSessionCoordinator.swift
+++ b/Lazyflow/Sources/ViewModels/FocusSessionCoordinator.swift
@@ -8,10 +8,10 @@ final class FocusSessionCoordinator: ObservableObject {
 
     // MARK: - Persistence Keys
 
-    private static let focusTaskIDKey = "focusSessionTaskID"
-    private static let focusStartedAtKey = "focusSessionStartedAt"
-    private static let focusIsPausedKey = "focusSessionIsPaused"
-    private static let focusIsOnBreakKey = "focusSessionIsOnBreak"
+    private static let focusTaskIDKey = AppConstants.StorageKey.focusSessionTaskID
+    private static let focusStartedAtKey = AppConstants.StorageKey.focusSessionStartedAt
+    private static let focusIsPausedKey = AppConstants.StorageKey.focusSessionIsPaused
+    private static let focusIsOnBreakKey = AppConstants.StorageKey.focusSessionIsOnBreak
 
     // MARK: - Published State
 
@@ -56,14 +56,14 @@ final class FocusSessionCoordinator: ObservableObject {
 
     /// Pomodoro work interval in seconds. User-configurable via Settings.
     var pomodoroWorkInterval: TimeInterval {
-        let minutes = UserDefaults.standard.double(forKey: "pomodoroWorkMinutes")
-        return minutes > 0 ? minutes * 60 : 25 * 60
+        let minutes = UserDefaults.standard.double(forKey: AppConstants.StorageKey.pomodoroWorkMinutes)
+        return minutes > 0 ? minutes * 60 : AppConstants.Defaults.pomodoroWorkMinutes * 60
     }
 
     /// Pomodoro break interval in seconds. User-configurable via Settings.
     var pomodoroBreakInterval: TimeInterval {
-        let minutes = UserDefaults.standard.double(forKey: "pomodoroBreakMinutes")
-        return minutes > 0 ? minutes * 60 : 5 * 60
+        let minutes = UserDefaults.standard.double(forKey: AppConstants.StorageKey.pomodoroBreakMinutes)
+        return minutes > 0 ? minutes * 60 : AppConstants.Defaults.pomodoroBreakMinutes * 60
     }
 
     /// Timestamp when current Pomodoro interval started (for countdown)

--- a/Lazyflow/Sources/ViewModels/HistoryViewModel.swift
+++ b/Lazyflow/Sources/ViewModels/HistoryViewModel.swift
@@ -165,7 +165,7 @@ final class HistoryViewModel: ObservableObject {
 
         // Debounced search
         $searchQuery
-            .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
+            .debounce(for: .seconds(AppConstants.Timing.searchDebounce), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.refreshTasks()
             }

--- a/Lazyflow/Sources/ViewModels/TodayViewModel.swift
+++ b/Lazyflow/Sources/ViewModels/TodayViewModel.swift
@@ -44,7 +44,7 @@ final class TodayViewModel: ObservableObject {
             .store(in: &cancellables)
 
         $searchQuery
-            .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
+            .debounce(for: .seconds(AppConstants.Timing.searchDebounce), scheduler: DispatchQueue.main)
             .sink { [weak self] query in
                 self?.filterTasks(query: query)
             }

--- a/Lazyflow/Sources/Views/AddTaskView.swift
+++ b/Lazyflow/Sources/Views/AddTaskView.swift
@@ -9,7 +9,7 @@ struct AddTaskView: View {
     @StateObject private var llmService = LLMService.shared
     @FocusState private var isTitleFocused: Bool
 
-    @AppStorage("aiAutoSuggest") private var aiAutoSuggest: Bool = true
+    @AppStorage(AppConstants.StorageKey.aiAutoSuggest) private var aiAutoSuggest: Bool = true
 
     @State private var showDatePicker = false
     @State private var showListPicker = false

--- a/Lazyflow/Sources/Views/CalendarView.swift
+++ b/Lazyflow/Sources/Views/CalendarView.swift
@@ -7,7 +7,7 @@ struct CalendarView: View {
     @StateObject private var taskService = TaskService.shared
     @State private var selectedDate = Date()
     @State private var currentWeekStart = Calendar.current.startOfWeek(for: Date())
-    @AppStorage("calendarViewMode") private var viewModeRaw: String = ""
+    @AppStorage(AppConstants.StorageKey.calendarViewMode) private var viewModeRaw: String = ""
     @State private var showingTimeBlockSheet = false
     @State private var pendingTask: Task?
     @State private var pendingDropTime: Date?

--- a/Lazyflow/Sources/Views/OnboardingView.swift
+++ b/Lazyflow/Sources/Views/OnboardingView.swift
@@ -4,7 +4,7 @@ import UserNotifications
 
 /// Onboarding tutorial carousel for first-time users
 struct OnboardingView: View {
-    @AppStorage("hasSeenOnboarding") private var hasCompletedOnboarding = false
+    @AppStorage(AppConstants.StorageKey.hasSeenOnboarding) private var hasCompletedOnboarding = false
     @State private var currentPage = 0
     @State private var calendarPermissionGranted = false
     @State private var notificationPermissionGranted = false

--- a/Lazyflow/Sources/Views/PlanYourDayView.swift
+++ b/Lazyflow/Sources/Views/PlanYourDayView.swift
@@ -5,7 +5,7 @@ struct PlanYourDayView: View {
     @StateObject private var viewModel = PlanYourDayViewModel()
     @Environment(\.dismiss) private var dismiss
     @Environment(\.scenePhase) private var scenePhase
-    @AppStorage("autoHideSkippedEvents") private var autoHideSkippedEvents = false
+    @AppStorage(AppConstants.StorageKey.autoHideSkippedEvents) private var autoHideSkippedEvents = false
     @State private var showHiddenEvents = false
     private let learningService = EventPreferenceLearningService.shared
 

--- a/Lazyflow/Sources/Views/RootView.swift
+++ b/Lazyflow/Sources/Views/RootView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// Root view - shows UI immediately, no loading screen
 struct RootView: View {
-    @AppStorage("hasSeenOnboarding") private var hasCompletedOnboarding = false
+    @AppStorage(AppConstants.StorageKey.hasSeenOnboarding) private var hasCompletedOnboarding = false
 
     /// Check if running in UI test mode - bypasses onboarding
     private var isUITesting: Bool {
@@ -20,7 +20,7 @@ struct RootView: View {
                         PersistenceController.shared.createDefaultListsIfNeeded()
 
                         // Start calendar sync if enabled
-                        if UserDefaults.standard.bool(forKey: "calendarAutoSync") {
+                        if UserDefaults.standard.bool(forKey: AppConstants.StorageKey.calendarAutoSync) {
                             CalendarSyncService.shared.startObserving()
                         }
                     }

--- a/Lazyflow/Sources/Views/SettingsView.swift
+++ b/Lazyflow/Sources/Views/SettingsView.swift
@@ -3,13 +3,13 @@ import SwiftUI
 /// Settings view for app configuration
 struct SettingsView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @AppStorage("appearanceMode") private var appearanceMode: AppearanceMode = .system
-    @AppStorage("defaultReminderTime") private var defaultReminderTime: Int = 9
-    @AppStorage("showCompletedTasks") private var showCompletedTasks: Bool = true
-    @AppStorage("hapticFeedback") private var hapticFeedback: Bool = true
-    @AppStorage("summaryPromptHour") private var summaryPromptHour: Int = 18
-    @AppStorage("pomodoroWorkMinutes") private var pomodoroWorkMinutes: Double = 25
-    @AppStorage("pomodoroBreakMinutes") private var pomodoroBreakMinutes: Double = 5
+    @AppStorage(AppConstants.StorageKey.appearanceMode) private var appearanceMode: AppearanceMode = .system
+    @AppStorage(AppConstants.StorageKey.defaultReminderTime) private var defaultReminderTime: Int = AppConstants.Defaults.reminderHour
+    @AppStorage(AppConstants.StorageKey.showCompletedTasks) private var showCompletedTasks: Bool = true
+    @AppStorage(AppConstants.StorageKey.hapticFeedback) private var hapticFeedback: Bool = true
+    @AppStorage(AppConstants.StorageKey.summaryPromptHour) private var summaryPromptHour: Int = AppConstants.Defaults.summaryPromptHour
+    @AppStorage(AppConstants.StorageKey.pomodoroWorkMinutes) private var pomodoroWorkMinutes: Double = AppConstants.Defaults.pomodoroWorkMinutes
+    @AppStorage(AppConstants.StorageKey.pomodoroBreakMinutes) private var pomodoroBreakMinutes: Double = AppConstants.Defaults.pomodoroBreakMinutes
 
     @State private var showAbout = false
     @State private var showNotificationSettings = false
@@ -78,8 +78,8 @@ struct SettingsView: View {
                 // Plan Your Day
                 Section {
                     Toggle("Auto-Hide Frequently Skipped", isOn: Binding(
-                        get: { UserDefaults.standard.bool(forKey: "autoHideSkippedEvents") },
-                        set: { UserDefaults.standard.set($0, forKey: "autoHideSkippedEvents") }
+                        get: { UserDefaults.standard.bool(forKey: AppConstants.StorageKey.autoHideSkippedEvents) },
+                        set: { UserDefaults.standard.set($0, forKey: AppConstants.StorageKey.autoHideSkippedEvents) }
                     ))
                 } header: {
                     Text("Plan Your Day")
@@ -854,9 +854,9 @@ struct AISettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @StateObject private var llmService = LLMService.shared
     @StateObject private var taskService = TaskService.shared
-    @AppStorage("aiAutoSuggest") private var aiAutoSuggest: Bool = true
-    @AppStorage("aiEstimateDuration") private var aiEstimateDuration: Bool = true
-    @AppStorage("aiSuggestPriority") private var aiSuggestPriority: Bool = true
+    @AppStorage(AppConstants.StorageKey.aiAutoSuggest) private var aiAutoSuggest: Bool = true
+    @AppStorage(AppConstants.StorageKey.aiEstimateDuration) private var aiEstimateDuration: Bool = true
+    @AppStorage(AppConstants.StorageKey.aiSuggestPriority) private var aiSuggestPriority: Bool = true
 
     @State private var isBatchAnalyzing = false
     @State private var batchAnalysisProgress: Int = 0
@@ -1330,7 +1330,7 @@ struct BatchAnalysisResultRow: View {
 // MARK: - Morning Briefing Prompt Toggle
 
 struct MorningBriefingPromptToggle: View {
-    @AppStorage("morningBriefingEnabled") private var isEnabled = true
+    @AppStorage(AppConstants.StorageKey.morningBriefingEnabled) private var isEnabled = true
 
     var body: some View {
         Toggle(isOn: $isEnabled) {
@@ -1348,8 +1348,8 @@ struct MorningBriefingPromptToggle: View {
 // MARK: - Morning Briefing Notification Toggle
 
 struct MorningBriefingNotificationToggle: View {
-    @AppStorage("morningBriefingNotificationEnabled") private var isEnabled = false
-    @AppStorage("morningBriefingNotificationHour") private var notificationHour = 7 // 7 AM default
+    @AppStorage(AppConstants.StorageKey.morningBriefingNotificationEnabled) private var isEnabled = false
+    @AppStorage(AppConstants.StorageKey.morningBriefingNotificationHour) private var notificationHour = AppConstants.Defaults.morningBriefingNotificationHour
 
     private let notificationService = NotificationService.shared
 
@@ -1408,8 +1408,8 @@ struct MorningBriefingNotificationToggle: View {
 // MARK: - Daily Summary Notification Toggle
 
 struct DailySummaryNotificationToggle: View {
-    @AppStorage("dailySummaryNotificationEnabled") private var isEnabled = false
-    @AppStorage("dailySummaryNotificationHour") private var notificationHour = 20 // 8 PM default
+    @AppStorage(AppConstants.StorageKey.dailySummaryNotificationEnabled) private var isEnabled = false
+    @AppStorage(AppConstants.StorageKey.dailySummaryNotificationHour) private var notificationHour = AppConstants.Defaults.dailySummaryNotificationHour
     @State private var showTimePicker = false
 
     private let notificationService = NotificationService.shared
@@ -2094,9 +2094,9 @@ struct ModelDetailSheet: View {
 // MARK: - Calendar Sync Toggle
 
 struct CalendarSyncToggle: View {
-    @AppStorage("calendarAutoSync") private var calendarAutoSync = false
-    @AppStorage("calendarCompletionPolicy") private var completionPolicy = "keep"
-    @AppStorage("calendarBusyOnly") private var busyOnly = false
+    @AppStorage(AppConstants.StorageKey.calendarAutoSync) private var calendarAutoSync = false
+    @AppStorage(AppConstants.StorageKey.calendarCompletionPolicy) private var completionPolicy = "keep"
+    @AppStorage(AppConstants.StorageKey.calendarBusyOnly) private var busyOnly = false
     @State private var isRequestingAccess = false
 
     var body: some View {

--- a/Lazyflow/Sources/Views/SubtaskDetailView.swift
+++ b/Lazyflow/Sources/Views/SubtaskDetailView.swift
@@ -9,7 +9,7 @@ struct SubtaskDetailView: View {
     @StateObject private var taskService = TaskService.shared
     @FocusState private var isTitleFocused: Bool
 
-    @AppStorage("aiAutoSuggest") private var aiAutoSuggest: Bool = true
+    @AppStorage(AppConstants.StorageKey.aiAutoSuggest) private var aiAutoSuggest: Bool = true
 
     @State private var showAISuggestions = false
     @State private var aiAnalysis: TaskAnalysis?

--- a/Lazyflow/Sources/Views/TaskDetailView.swift
+++ b/Lazyflow/Sources/Views/TaskDetailView.swift
@@ -10,7 +10,7 @@ struct TaskDetailView: View {
     @StateObject private var categoryService = CategoryService.shared
     @FocusState private var isTitleFocused: Bool
 
-    @AppStorage("aiAutoSuggest") private var aiAutoSuggest: Bool = true
+    @AppStorage(AppConstants.StorageKey.aiAutoSuggest) private var aiAutoSuggest: Bool = true
 
     @State private var showAISuggestions = false
     @State private var aiAnalysis: TaskAnalysis?

--- a/Lazyflow/Sources/Views/TodayView.swift
+++ b/Lazyflow/Sources/Views/TodayView.swift
@@ -26,10 +26,10 @@ struct TodayView: View {
     @State private var autoCompletedParentTitle = ""
     @StateObject private var summaryService = DailySummaryService.shared
     @StateObject private var listService = TaskListService.shared
-    @AppStorage("summaryPromptHour") private var summaryPromptHour: Int = 18
-    @AppStorage("morningBriefingEnabled") private var morningBriefingEnabled: Bool = true
-    @AppStorage("lastMorningBriefingDate") private var lastMorningBriefingDate: Double = 0
-    @AppStorage("lastPlanYourDayDate") private var lastPlanYourDayDate: Double = 0
+    @AppStorage(AppConstants.StorageKey.summaryPromptHour) private var summaryPromptHour: Int = AppConstants.Defaults.summaryPromptHour
+    @AppStorage(AppConstants.StorageKey.morningBriefingEnabled) private var morningBriefingEnabled: Bool = true
+    @AppStorage(AppConstants.StorageKey.lastMorningBriefingDate) private var lastMorningBriefingDate: Double = 0
+    @AppStorage(AppConstants.StorageKey.lastPlanYourDayDate) private var lastPlanYourDayDate: Double = 0
     @State private var showPlanYourDay = false
     @State private var actionToast: ActionToastData?
     @State private var highlightedTaskID: UUID?


### PR DESCRIPTION
## Summary
- Add `AppConstants.swift` with type-safe `StorageKey`, `Defaults`, `Timing`, and `Limits` enums
- Replace 50+ scattered magic strings (`@AppStorage`, `UserDefaults.standard`) across 27 files with centralized constants
- Eliminate raw string UserDefaults keys that were duplicated between views and services (e.g., `"calendarAutoSync"` appeared in 4 files)

## Test plan
- [x] Build compiles cleanly
- [x] 230/230 unit tests pass (2 failures are system resource kills, not code)
- [ ] Verify settings persistence works end-to-end (appearance, pomodoro, calendar sync)
- [ ] Verify AI features still read correct defaults

Closes #246