### PR TITLE
fix(ai): check device capability before showing AI features

### DIFF
--- a/Lazyflow/Sources/Services/AI/LLM/AppleFoundationModelsProvider.swift
+++ b/Lazyflow/Sources/Services/AI/LLM/AppleFoundationModelsProvider.swift
@@ -14,7 +14,7 @@ final class AppleFoundationModelsProvider: LLMProvider {
     var isAvailable: Bool {
         #if canImport(FoundationModels)
         if #available(iOS 26.0, *) {
-            return true
+            return SystemLanguageModel.default.isAvailable
         }
         #endif
         return false


### PR DESCRIPTION
## Summary
- Use `SystemLanguageModel.default.isAvailable` instead of just iOS version check in `AppleFoundationModelsProvider`
- Prevents the AI magic wand from appearing on devices that don't support Apple Intelligence (requires A17 Pro or later)
- One-line fix: `return true` → `return SystemLanguageModel.default.isAvailable`

## Test plan
- [ ] Build succeeds on iPhone 17 Pro simulator
- [ ] CI build-and-test passes
- [ ] On unsupported device (e.g. iPhone 14), magic wand does NOT appear in Add Task
- [ ] On supported device (e.g. iPhone 17 Pro), magic wand still appears and works

Closes #281