### PR TITLE
fix(ui): split date and time block into focused picker sheets

### DIFF
--- a/Lazyflow/Sources/Views/AddTask/AddTaskView+QuickActions.swift
+++ b/Lazyflow/Sources/Views/AddTask/AddTaskView+QuickActions.swift
@@ -8,18 +8,8 @@ extension AddTaskView {
 
     var quickActionsGrid: some View {
         VStack(spacing: DesignSystem.Spacing.sm) {
-            // Row 1: Date options
+            // Row 1: Today, Date, Time
             HStack(spacing: DesignSystem.Spacing.sm) {
-                // Due Date picker
-                QuickActionButton(
-                    icon: "calendar",
-                    title: dateButtonTitle,
-                    isSelected: addTaskViewModel.hasDueDate,
-                    color: Color.Lazyflow.accent
-                ) {
-                    showDatePicker = true
-                }
-
                 // Today quick action
                 QuickActionButton(
                     icon: "star",
@@ -30,49 +20,39 @@ extension AddTaskView {
                     addTaskViewModel.setDueToday()
                 }
 
-                // Tomorrow quick action
+                // Due Date picker
                 QuickActionButton(
-                    icon: "sunrise",
-                    title: "Tomorrow",
-                    isSelected: addTaskViewModel.dueDate?.isTomorrow == true,
-                    color: Color.Lazyflow.priorityMedium
-                ) {
-                    addTaskViewModel.setDueTomorrow()
-                }
-            }
-
-            // Row 2: Time Block, Remind, Repeat
-            HStack(spacing: DesignSystem.Spacing.sm) {
-                QuickActionButton(
-                    icon: "timer",
-                    title: timeBlockButtonTitle,
-                    isSelected: addTaskViewModel.hasDueTime || addTaskViewModel.estimatedDuration != nil,
+                    icon: "calendar",
+                    title: dateButtonTitle,
+                    isSelected: addTaskViewModel.hasDueDate,
                     color: Color.Lazyflow.accent
                 ) {
-                    showTimeBlockSheet = true
+                    showDatePicker = true
                 }
 
+                // Time
                 QuickActionButton(
-                    icon: addTaskViewModel.hasReminder ? "bell.fill" : "bell",
-                    title: addTaskViewModel.hasReminder ? formatReminderTime(addTaskViewModel.reminderDate) : "Remind",
-                    isSelected: addTaskViewModel.hasReminder,
-                    color: Color.Lazyflow.info
+                    icon: "clock",
+                    title: timeButtonTitle,
+                    isSelected: addTaskViewModel.hasDueTime,
+                    color: Color.Lazyflow.accent
                 ) {
-                    showReminderSheet = true
-                }
-
-                QuickActionButton(
-                    icon: "repeat",
-                    title: addTaskViewModel.isRecurring ? recurringDisplayTitle : "Repeat",
-                    isSelected: addTaskViewModel.isRecurring,
-                    color: Color.Lazyflow.info
-                ) {
-                    showRecurringSheet = true
+                    showTimeSheet = true
                 }
             }
 
-            // Row 3: Priority, Category, List
+            // Row 2: Duration, Priority, Category
             HStack(spacing: DesignSystem.Spacing.sm) {
+                // Duration
+                QuickActionButton(
+                    icon: "timer",
+                    title: durationButtonTitle,
+                    isSelected: addTaskViewModel.estimatedDuration != nil,
+                    color: Color.Lazyflow.accent
+                ) {
+                    showDurationSheet = true
+                }
+
                 // Priority
                 Menu {
                     ForEach(Priority.allCases) { priority in
@@ -122,7 +102,10 @@ extension AddTaskView {
                         color: categoryDisplayColor
                     )
                 }
+            }
 
+            // Row 3: List, Remind, Repeat
+            HStack(spacing: DesignSystem.Spacing.sm) {
                 // List
                 QuickActionButton(
                     icon: "folder",
@@ -131,6 +114,26 @@ extension AddTaskView {
                     color: Color.Lazyflow.textTertiary
                 ) {
                     showListPicker = true
+                }
+
+                // Remind
+                QuickActionButton(
+                    icon: addTaskViewModel.hasReminder ? "bell.fill" : "bell",
+                    title: addTaskViewModel.hasReminder ? formatReminderTime(addTaskViewModel.reminderDate) : "Remind",
+                    isSelected: addTaskViewModel.hasReminder,
+                    color: Color.Lazyflow.info
+                ) {
+                    showReminderSheet = true
+                }
+
+                // Repeat
+                QuickActionButton(
+                    icon: "repeat",
+                    title: addTaskViewModel.isRecurring ? recurringDisplayTitle : "Repeat",
+                    isSelected: addTaskViewModel.isRecurring,
+                    color: Color.Lazyflow.info
+                ) {
+                    showRecurringSheet = true
                 }
             }
         }
@@ -276,14 +279,24 @@ extension AddTaskView {
                     )
                 }
 
-                if addTaskViewModel.hasDueTime || addTaskViewModel.estimatedDuration != nil {
+                if addTaskViewModel.hasDueTime {
                     SelectedOptionChip(
-                        icon: "timer",
-                        title: timeBlockChipTitle,
+                        icon: "clock",
+                        title: timeChipTitle,
                         color: Color.Lazyflow.accent,
                         onRemove: {
                             addTaskViewModel.hasDueTime = false
                             addTaskViewModel.dueTime = nil
+                        }
+                    )
+                }
+
+                if addTaskViewModel.estimatedDuration != nil {
+                    SelectedOptionChip(
+                        icon: "timer",
+                        title: formatDuration(addTaskViewModel.estimatedDuration!),
+                        color: Color.Lazyflow.accent,
+                        onRemove: {
                             addTaskViewModel.estimatedDuration = nil
                         }
                     )

--- a/Lazyflow/Sources/Views/AddTask/AddTaskView.swift
+++ b/Lazyflow/Sources/Views/AddTask/AddTaskView.swift
@@ -14,7 +14,8 @@ struct AddTaskView: View {
     @AppStorage(AppConstants.StorageKey.aiAutoSuggest) private var aiAutoSuggest: Bool = true
 
     @State var showDatePicker = false
-    @State var showTimeBlockSheet = false
+    @State var showTimeSheet = false
+    @State var showDurationSheet = false
     @State var showListPicker = false
     @State var showAISuggestions = false
     @State var aiAnalysis: TaskAnalysis?
@@ -188,15 +189,18 @@ struct AddTaskView: View {
                 )
                 .presentationDetents([.medium, .large])
             }
-            .sheet(isPresented: $showTimeBlockSheet) {
+            .sheet(isPresented: $showTimeSheet) {
                 TimeBlockSheet(
                     selectedDate: $viewModel.dueDate,
                     hasDate: $viewModel.hasDueDate,
                     selectedTime: $viewModel.dueTime,
-                    hasTime: $viewModel.hasDueTime,
-                    estimatedDuration: $viewModel.estimatedDuration
+                    hasTime: $viewModel.hasDueTime
                 )
-                .presentationDetents([.medium, .large])
+                .presentationDetents([.height(380)])
+            }
+            .sheet(isPresented: $showDurationSheet) {
+                DurationPickerSheet(estimatedDuration: $viewModel.estimatedDuration)
+                    .presentationDetents([.height(380)])
             }
             .sheet(isPresented: $showListPicker) {
                 ListPickerSheet(
@@ -486,42 +490,27 @@ struct AddTaskView: View {
         return date.shortFormatted
     }
 
-    var timeBlockButtonTitle: String {
-        let hasTime = viewModel.hasDueTime
-        let hasDuration = viewModel.estimatedDuration != nil
+    var timeButtonTitle: String {
+        guard viewModel.hasDueTime, let time = viewModel.dueTime else { return "Time" }
+        let tf = DateFormatter()
+        tf.dateFormat = "h:mm a"
+        return tf.string(from: time)
+    }
 
-        if hasTime, let time = viewModel.dueTime, hasDuration, let duration = viewModel.estimatedDuration {
-            let tf = DateFormatter()
-            tf.timeStyle = .short
-            tf.dateStyle = .none
-            return "\(tf.string(from: time)) · \(formatDuration(duration))"
-        } else if hasTime, let time = viewModel.dueTime {
-            let tf = DateFormatter()
-            tf.timeStyle = .short
-            tf.dateStyle = .none
-            return tf.string(from: time)
-        } else if hasDuration, let duration = viewModel.estimatedDuration {
-            return formatDuration(duration)
-        }
-        return "Time Block"
+    var durationButtonTitle: String {
+        guard let duration = viewModel.estimatedDuration else { return "Duration" }
+        return formatDuration(duration)
     }
 
     func dateChipTitle(date: Date) -> String {
         return date.relativeFormatted
     }
 
-    var timeBlockChipTitle: String {
-        var parts: [String] = []
-        if viewModel.hasDueTime, let time = viewModel.dueTime {
-            let tf = DateFormatter()
-            tf.timeStyle = .short
-            tf.dateStyle = .none
-            parts.append(tf.string(from: time))
-        }
-        if let duration = viewModel.estimatedDuration {
-            parts.append(formatDuration(duration))
-        }
-        return parts.joined(separator: " · ")
+    var timeChipTitle: String {
+        guard viewModel.hasDueTime, let time = viewModel.dueTime else { return "" }
+        let tf = DateFormatter()
+        tf.dateFormat = "h:mm a"
+        return tf.string(from: time)
     }
 
     var selectedListName: String {

--- a/Lazyflow/Sources/Views/Sheets/DurationPickerSheet.swift
+++ b/Lazyflow/Sources/Views/Sheets/DurationPickerSheet.swift
@@ -9,96 +9,75 @@ struct DurationPickerSheet: View {
     @State private var customHours: Int = 0
     @State private var customMinutes: Int = 0
 
-    private static let hourOptions = Array(0...4)
-    private static let minuteOptions = stride(from: 0, through: 55, by: 5).map { $0 }
-
     var body: some View {
         NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
-                    // MARK: - Quick Presets
-                    Text("Quick Pick")
-                        .font(DesignSystem.Typography.footnote)
-                        .fontWeight(.semibold)
-                        .foregroundColor(Color.Lazyflow.textSecondary)
-                        .textCase(.uppercase)
-                        .padding(.horizontal)
+            VStack(spacing: 0) {
+                // MARK: - Preset Chips
 
-                    LazyVGrid(columns: [
-                        GridItem(.flexible()),
-                        GridItem(.flexible()),
-                        GridItem(.flexible()),
-                        GridItem(.flexible())
-                    ], spacing: DesignSystem.Spacing.sm) {
-                        ForEach(TaskViewModel.durationPresets, id: \.0) { preset in
-                            DurationChip(
-                                title: preset.0,
-                                isSelected: estimatedDuration == preset.1,
-                                action: {
-                                    withAnimation(.easeInOut(duration: 0.2)) {
-                                        if estimatedDuration == preset.1 {
-                                            estimatedDuration = nil
-                                            customHours = 0
-                                            customMinutes = 0
-                                        } else {
-                                            estimatedDuration = preset.1
-                                            syncWheelsFromDuration()
-                                        }
+                LazyVGrid(columns: [
+                    GridItem(.flexible()),
+                    GridItem(.flexible()),
+                    GridItem(.flexible()),
+                    GridItem(.flexible())
+                ], spacing: DesignSystem.Spacing.sm) {
+                    ForEach(TaskViewModel.durationPresets, id: \.0) { preset in
+                        DurationChip(
+                            title: preset.0,
+                            isSelected: estimatedDuration == preset.1,
+                            action: {
+                                withAnimation(.easeInOut(duration: 0.2)) {
+                                    if estimatedDuration == preset.1 {
+                                        estimatedDuration = nil
+                                        customHours = 0
+                                        customMinutes = 0
+                                    } else {
+                                        estimatedDuration = preset.1
+                                        syncWheelsFromDuration()
                                     }
                                 }
-                            )
-                        }
-                    }
-                    .padding(.horizontal)
-
-                    Divider()
-                        .padding(.horizontal)
-
-                    // MARK: - Custom Duration Dial
-                    Text("Custom")
-                        .font(DesignSystem.Typography.footnote)
-                        .fontWeight(.semibold)
-                        .foregroundColor(Color.Lazyflow.textSecondary)
-                        .textCase(.uppercase)
-                        .padding(.horizontal)
-
-                    HStack(spacing: 0) {
-                        Picker("Hours", selection: $customHours) {
-                            ForEach(Self.hourOptions, id: \.self) { hour in
-                                Text("\(hour)").tag(hour)
                             }
-                        }
-                        .pickerStyle(.wheel)
-                        .frame(maxWidth: .infinity)
-
-                        Text("hours")
-                            .font(DesignSystem.Typography.body)
-                            .fontWeight(.medium)
-                            .foregroundColor(Color.Lazyflow.textSecondary)
-
-                        Picker("Minutes", selection: $customMinutes) {
-                            ForEach(Self.minuteOptions, id: \.self) { min in
-                                Text("\(min)").tag(min)
-                            }
-                        }
-                        .pickerStyle(.wheel)
-                        .frame(maxWidth: .infinity)
-
-                        Text("min")
-                            .font(DesignSystem.Typography.body)
-                            .fontWeight(.medium)
-                            .foregroundColor(Color.Lazyflow.textSecondary)
-                    }
-                    .frame(height: 150)
-                    .padding(.horizontal)
-                    .onChange(of: customHours) { _, _ in
-                        updateDurationFromWheels()
-                    }
-                    .onChange(of: customMinutes) { _, _ in
-                        updateDurationFromWheels()
+                        )
                     }
                 }
-                .padding(.top, DesignSystem.Spacing.lg)
+                .padding(.horizontal)
+                .padding(.top, DesignSystem.Spacing.sm)
+
+                // MARK: - Custom Wheels
+
+                HStack(spacing: 0) {
+                    Picker("Hours", selection: $customHours) {
+                        ForEach(0...4, id: \.self) { hour in
+                            Text("\(hour)").tag(hour)
+                        }
+                    }
+                    .pickerStyle(.wheel)
+                    .frame(maxWidth: .infinity)
+
+                    Text("hours")
+                        .font(DesignSystem.Typography.body)
+                        .fontWeight(.medium)
+                        .foregroundColor(Color.Lazyflow.textSecondary)
+
+                    Picker("Minutes", selection: $customMinutes) {
+                        ForEach(Array(stride(from: 0, through: 55, by: 5)), id: \.self) { min in
+                            Text("\(min)").tag(min)
+                        }
+                    }
+                    .pickerStyle(.wheel)
+                    .frame(maxWidth: .infinity)
+
+                    Text("min")
+                        .font(DesignSystem.Typography.body)
+                        .fontWeight(.medium)
+                        .foregroundColor(Color.Lazyflow.textSecondary)
+                }
+                .padding(.horizontal)
+                .onChange(of: customHours) { _, _ in
+                    updateDurationFromWheels()
+                }
+                .onChange(of: customMinutes) { _, _ in
+                    updateDurationFromWheels()
+                }
             }
             .navigationTitle("Duration")
             .navigationBarTitleDisplayMode(.inline)
@@ -119,7 +98,7 @@ struct DurationPickerSheet: View {
                     Button("Done") {
                         dismiss()
                     }
-                    .fontWeight(.semibold)
+                    .fontWeight(.bold)
                 }
             }
             .onAppear {
@@ -136,7 +115,6 @@ struct DurationPickerSheet: View {
         }
         let totalMinutes = Int(duration / 60)
         customHours = totalMinutes / 60
-        // Round to nearest 5-minute increment
         customMinutes = (totalMinutes % 60 / 5) * 5
     }
 

--- a/Lazyflow/Sources/Views/Sheets/TimeBlockSheet.swift
+++ b/Lazyflow/Sources/Views/Sheets/TimeBlockSheet.swift
@@ -9,150 +9,56 @@ struct TimeBlockSheet: View {
     @Binding var hasDate: Bool
     @Binding var selectedTime: Date?
     @Binding var hasTime: Bool
-    @Binding var estimatedDuration: TimeInterval?
-
-    @State private var isCustomDurationExpanded = false
-    @State private var customHours = 0
-    @State private var customMinutes = 0
 
     var body: some View {
         NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
-                    // MARK: - Quick Time Chips
+            VStack(spacing: 0) {
+                // MARK: - Quick Time Chips
 
-                    HStack(spacing: DesignSystem.Spacing.md) {
-                        TimeQuickOption(title: "Morning", hour: 9) {
-                            setTime(hour: 9, minute: 0)
-                        }
-                        TimeQuickOption(title: "Afternoon", hour: 13) {
-                            setTime(hour: 13, minute: 0)
-                        }
-                        TimeQuickOption(title: "Evening", hour: 18) {
-                            setTime(hour: 18, minute: 0)
-                        }
+                HStack(spacing: DesignSystem.Spacing.sm) {
+                    TimeQuickOption(title: "Morning", hour: 9) {
+                        setTime(hour: 9, minute: 0)
                     }
-                    .padding(.horizontal)
-
-                    // MARK: - Start Time Picker
-
-                    DatePicker(
-                        "Start Time",
-                        selection: Binding(
-                            get: { selectedTime ?? nextQuarterHour() },
-                            set: {
-                                selectedTime = $0
-                                hasTime = true
-                            }
-                        ),
-                        displayedComponents: .hourAndMinute
-                    )
-                    .font(DesignSystem.Typography.body)
-                    .datePickerStyle(.compact)
-                    .padding(.horizontal)
-
-                    Divider()
-                        .padding(.horizontal)
-
-                    // MARK: - Duration Section Header
-
-                    Text("Duration")
-                        .font(DesignSystem.Typography.headline)
-                        .foregroundColor(Color.Lazyflow.textPrimary)
-                        .padding(.horizontal)
-
-                    // MARK: - Duration Preset Chips
-
-                    LazyVGrid(columns: [
-                        GridItem(.flexible()),
-                        GridItem(.flexible()),
-                        GridItem(.flexible()),
-                        GridItem(.flexible())
-                    ], spacing: DesignSystem.Spacing.sm) {
-                        ForEach(TaskViewModel.durationPresets, id: \.0) { preset in
-                            DurationChip(
-                                title: preset.0,
-                                isSelected: estimatedDuration == preset.1,
-                                action: {
-                                    withAnimation(.easeInOut(duration: 0.2)) {
-                                        if estimatedDuration == preset.1 {
-                                            estimatedDuration = nil
-                                            customHours = 0
-                                            customMinutes = 0
-                                        } else {
-                                            estimatedDuration = preset.1
-                                            syncCustomWheelsFromDuration()
-                                        }
-                                    }
-                                }
-                            )
-                        }
+                    TimeQuickOption(title: "Afternoon", hour: 13) {
+                        setTime(hour: 13, minute: 0)
                     }
-                    .padding(.horizontal)
-
-                    // MARK: - Custom Duration
-
-                    DisclosureGroup("Custom", isExpanded: $isCustomDurationExpanded) {
-                        HStack(spacing: DesignSystem.Spacing.lg) {
-                            VStack(spacing: DesignSystem.Spacing.xs) {
-                                Picker("Hours", selection: $customHours) {
-                                    ForEach(0...4, id: \.self) { hour in
-                                        Text("\(hour)").tag(hour)
-                                    }
-                                }
-                                .pickerStyle(.wheel)
-                                .frame(width: 80, height: 120)
-                                .clipped()
-
-                                Text("hours")
-                                    .font(DesignSystem.Typography.caption1)
-                                    .foregroundColor(Color.Lazyflow.textSecondary)
-                            }
-
-                            VStack(spacing: DesignSystem.Spacing.xs) {
-                                Picker("Minutes", selection: $customMinutes) {
-                                    ForEach(Array(stride(from: 0, through: 55, by: 5)), id: \.self) { minute in
-                                        Text("\(minute)").tag(minute)
-                                    }
-                                }
-                                .pickerStyle(.wheel)
-                                .frame(width: 80, height: 120)
-                                .clipped()
-
-                                Text("min")
-                                    .font(DesignSystem.Typography.caption1)
-                                    .foregroundColor(Color.Lazyflow.textSecondary)
-                            }
-                        }
-                        .frame(maxWidth: .infinity)
-                        .padding(.top, DesignSystem.Spacing.sm)
-                        .onChange(of: customHours) { _, _ in
-                            syncDurationFromCustomWheels()
-                        }
-                        .onChange(of: customMinutes) { _, _ in
-                            syncDurationFromCustomWheels()
-                        }
+                    TimeQuickOption(title: "Evening", hour: 18) {
+                        setTime(hour: 18, minute: 0)
                     }
-                    .font(DesignSystem.Typography.subheadline)
-                    .foregroundColor(Color.Lazyflow.textSecondary)
-                    .padding(.horizontal)
                 }
-                .padding(.top)
+                .padding(.horizontal)
+                .padding(.top, DesignSystem.Spacing.sm)
+                .padding(.bottom, DesignSystem.Spacing.xs)
+
+                // MARK: - Time Wheel
+
+                DatePicker(
+                    "Start Time",
+                    selection: Binding(
+                        get: { selectedTime ?? nextQuarterHour() },
+                        set: {
+                            selectedTime = $0
+                            hasTime = true
+                        }
+                    ),
+                    displayedComponents: .hourAndMinute
+                )
+                .datePickerStyle(.wheel)
+                .labelsHidden()
+                .padding(.horizontal)
             }
-            .navigationTitle("Time Block")
+            .navigationTitle("Start Time")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
-                    Button("Clear") {
-                        selectedTime = nil
-                        hasTime = false
-                        estimatedDuration = nil
-                        customHours = 0
-                        customMinutes = 0
-                        isCustomDurationExpanded = false
-                        dismiss()
+                    if hasTime {
+                        Button("Clear") {
+                            selectedTime = nil
+                            hasTime = false
+                            dismiss()
+                        }
+                        .foregroundColor(Color.Lazyflow.error)
                     }
-                    .foregroundColor(Color.Lazyflow.error)
                 }
 
                 ToolbarItem(placement: .navigationBarTrailing) {
@@ -163,26 +69,13 @@ struct TimeBlockSheet: View {
                 }
             }
             .onAppear {
-                // Auto-set date to today if no date set
                 if !hasDate {
                     selectedDate = Date()
                     hasDate = true
                 }
-                // Auto-set time to next quarter hour if no time set
                 if selectedTime == nil {
                     selectedTime = nextQuarterHour()
                     hasTime = true
-                }
-                // Auto-set duration to 30 min if not set
-                if estimatedDuration == nil {
-                    estimatedDuration = 30 * 60
-                    customMinutes = 30
-                }
-                // Sync custom wheels from existing duration
-                if let duration = estimatedDuration {
-                    let totalMinutes = Int(duration) / 60
-                    customHours = totalMinutes / 60
-                    customMinutes = (totalMinutes % 60 / 5) * 5
                 }
             }
         }
@@ -207,26 +100,6 @@ struct TimeBlockSheet: View {
             hasTime = true
         }
     }
-
-    private func syncCustomWheelsFromDuration() {
-        guard let duration = estimatedDuration else {
-            customHours = 0
-            customMinutes = 0
-            return
-        }
-        let totalMinutes = Int(duration) / 60
-        customHours = min(totalMinutes / 60, 4)
-        customMinutes = (totalMinutes % 60 / 5) * 5
-    }
-
-    private func syncDurationFromCustomWheels() {
-        let totalSeconds = TimeInterval((customHours * 60 + customMinutes) * 60)
-        if totalSeconds > 0 {
-            estimatedDuration = totalSeconds
-        } else {
-            estimatedDuration = nil
-        }
-    }
 }
 
 // MARK: - Time Quick Option
@@ -238,7 +111,7 @@ private struct TimeQuickOption: View {
 
     var body: some View {
         Button(action: action) {
-            VStack(spacing: 4) {
+            VStack(spacing: 2) {
                 Text(title)
                     .font(DesignSystem.Typography.subheadline)
                     .fontWeight(.medium)
@@ -247,7 +120,7 @@ private struct TimeQuickOption: View {
                     .foregroundColor(Color.Lazyflow.textSecondary)
             }
             .frame(maxWidth: .infinity)
-            .padding(.vertical, DesignSystem.Spacing.md)
+            .padding(.vertical, DesignSystem.Spacing.sm)
             .background(Color.secondary.opacity(0.1))
             .cornerRadius(DesignSystem.CornerRadius.medium)
         }

--- a/Lazyflow/Sources/Views/TaskDetailView.swift
+++ b/Lazyflow/Sources/Views/TaskDetailView.swift
@@ -23,7 +23,8 @@ struct TaskDetailView: View {
 
     // Sheet states
     @State private var showDatePicker = false
-    @State private var showTimeBlockSheet = false
+    @State private var showTimeSheet = false
+    @State private var showDurationSheet = false
     @State private var showListPicker = false
     @State private var showRecurringSheet = false
     @State private var showReminderSheet = false
@@ -189,15 +190,18 @@ struct TaskDetailView: View {
                 )
                 .presentationDetents([.medium, .large])
             }
-            .sheet(isPresented: $showTimeBlockSheet) {
+            .sheet(isPresented: $showTimeSheet) {
                 TimeBlockSheet(
                     selectedDate: $viewModel.dueDate,
                     hasDate: $viewModel.hasDueDate,
                     selectedTime: $viewModel.dueTime,
-                    hasTime: $viewModel.hasDueTime,
-                    estimatedDuration: $viewModel.estimatedDuration
+                    hasTime: $viewModel.hasDueTime
                 )
-                .presentationDetents([.medium, .large])
+                .presentationDetents([.height(380)])
+            }
+            .sheet(isPresented: $showDurationSheet) {
+                DurationPickerSheet(estimatedDuration: $viewModel.estimatedDuration)
+                    .presentationDetents([.height(380)])
             }
             .sheet(isPresented: $showListPicker) {
                 ListPickerSheet(
@@ -292,18 +296,8 @@ struct TaskDetailView: View {
 
     private var quickActionsGrid: some View {
         VStack(spacing: DesignSystem.Spacing.sm) {
-            // Row 1: Date options
+            // Row 1: Today, Date, Time
             HStack(spacing: DesignSystem.Spacing.sm) {
-                // Due Date picker
-                QuickActionButton(
-                    icon: "calendar",
-                    title: dateButtonTitle,
-                    isSelected: viewModel.hasDueDate,
-                    color: Color.Lazyflow.accent
-                ) {
-                    showDatePicker = true
-                }
-
                 // Today quick action
                 QuickActionButton(
                     icon: "star",
@@ -314,49 +308,39 @@ struct TaskDetailView: View {
                     viewModel.setDueToday()
                 }
 
-                // Tomorrow quick action
+                // Due Date picker
                 QuickActionButton(
-                    icon: "sunrise",
-                    title: "Tomorrow",
-                    isSelected: viewModel.dueDate?.isTomorrow == true,
-                    color: Color.Lazyflow.priorityMedium
-                ) {
-                    viewModel.setDueTomorrow()
-                }
-            }
-
-            // Row 2: Time Block, Remind, Repeat
-            HStack(spacing: DesignSystem.Spacing.sm) {
-                QuickActionButton(
-                    icon: "timer",
-                    title: timeBlockButtonTitle,
-                    isSelected: viewModel.hasDueTime || viewModel.estimatedDuration != nil,
+                    icon: "calendar",
+                    title: dateButtonTitle,
+                    isSelected: viewModel.hasDueDate,
                     color: Color.Lazyflow.accent
                 ) {
-                    showTimeBlockSheet = true
+                    showDatePicker = true
                 }
 
+                // Time
                 QuickActionButton(
-                    icon: viewModel.hasReminder ? "bell.fill" : "bell",
-                    title: viewModel.hasReminder ? formatReminderTime(viewModel.reminderDate) : "Remind",
-                    isSelected: viewModel.hasReminder,
-                    color: Color.Lazyflow.info
+                    icon: "clock",
+                    title: timeButtonTitle,
+                    isSelected: viewModel.hasDueTime,
+                    color: Color.Lazyflow.accent
                 ) {
-                    showReminderSheet = true
-                }
-
-                QuickActionButton(
-                    icon: "repeat",
-                    title: viewModel.isRecurring ? recurringDisplayTitle : "Repeat",
-                    isSelected: viewModel.isRecurring,
-                    color: Color.Lazyflow.info
-                ) {
-                    showRecurringSheet = true
+                    showTimeSheet = true
                 }
             }
 
-            // Row 3: Priority, Category, List
+            // Row 2: Duration, Priority, Category
             HStack(spacing: DesignSystem.Spacing.sm) {
+                // Duration
+                QuickActionButton(
+                    icon: "timer",
+                    title: durationButtonTitle,
+                    isSelected: viewModel.estimatedDuration != nil,
+                    color: Color.Lazyflow.accent
+                ) {
+                    showDurationSheet = true
+                }
+
                 // Priority
                 Menu {
                     ForEach(Priority.allCases) { priority in
@@ -406,7 +390,10 @@ struct TaskDetailView: View {
                         color: categoryDisplayColor
                     )
                 }
+            }
 
+            // Row 3: List, Remind, Repeat
+            HStack(spacing: DesignSystem.Spacing.sm) {
                 // List
                 QuickActionButton(
                     icon: "folder",
@@ -415,6 +402,26 @@ struct TaskDetailView: View {
                     color: Color.Lazyflow.textTertiary
                 ) {
                     showListPicker = true
+                }
+
+                // Remind
+                QuickActionButton(
+                    icon: viewModel.hasReminder ? "bell.fill" : "bell",
+                    title: viewModel.hasReminder ? formatReminderTime(viewModel.reminderDate) : "Remind",
+                    isSelected: viewModel.hasReminder,
+                    color: Color.Lazyflow.info
+                ) {
+                    showReminderSheet = true
+                }
+
+                // Repeat
+                QuickActionButton(
+                    icon: "repeat",
+                    title: viewModel.isRecurring ? recurringDisplayTitle : "Repeat",
+                    isSelected: viewModel.isRecurring,
+                    color: Color.Lazyflow.info
+                ) {
+                    showRecurringSheet = true
                 }
             }
         }
@@ -557,14 +564,24 @@ struct TaskDetailView: View {
                     )
                 }
 
-                if viewModel.hasDueTime || viewModel.estimatedDuration != nil {
+                if viewModel.hasDueTime {
                     SelectedOptionChip(
-                        icon: "timer",
-                        title: timeBlockChipTitle,
+                        icon: "clock",
+                        title: timeChipTitle,
                         color: Color.Lazyflow.accent,
                         onRemove: {
                             viewModel.hasDueTime = false
                             viewModel.dueTime = nil
+                        }
+                    )
+                }
+
+                if viewModel.estimatedDuration != nil {
+                    SelectedOptionChip(
+                        icon: "timer",
+                        title: formatDuration(viewModel.estimatedDuration!),
+                        color: Color.Lazyflow.accent,
+                        onRemove: {
                             viewModel.estimatedDuration = nil
                         }
                     )
@@ -634,37 +651,23 @@ struct TaskDetailView: View {
         return viewModel.category.color
     }
 
-    private var timeBlockButtonTitle: String {
-        let hasTime = viewModel.hasDueTime
-        let hasDuration = viewModel.estimatedDuration != nil
-        if hasTime, let time = viewModel.dueTime, hasDuration, let duration = viewModel.estimatedDuration {
-            let tf = DateFormatter()
-            tf.timeStyle = .short
-            tf.dateStyle = .none
-            return "\(tf.string(from: time)) · \(formatDuration(duration))"
-        } else if hasTime, let time = viewModel.dueTime {
-            let tf = DateFormatter()
-            tf.timeStyle = .short
-            tf.dateStyle = .none
-            return tf.string(from: time)
-        } else if hasDuration, let duration = viewModel.estimatedDuration {
-            return formatDuration(duration)
-        }
-        return "Time Block"
+    private var timeButtonTitle: String {
+        guard viewModel.hasDueTime, let time = viewModel.dueTime else { return "Time" }
+        let tf = DateFormatter()
+        tf.dateFormat = "h:mm a"
+        return tf.string(from: time)
     }
 
-    private var timeBlockChipTitle: String {
-        var parts: [String] = []
-        if viewModel.hasDueTime, let time = viewModel.dueTime {
-            let tf = DateFormatter()
-            tf.timeStyle = .short
-            tf.dateStyle = .none
-            parts.append(tf.string(from: time))
-        }
-        if let duration = viewModel.estimatedDuration {
-            parts.append(formatDuration(duration))
-        }
-        return parts.joined(separator: " · ")
+    private var durationButtonTitle: String {
+        guard let duration = viewModel.estimatedDuration else { return "Duration" }
+        return formatDuration(duration)
+    }
+
+    private var timeChipTitle: String {
+        guard viewModel.hasDueTime, let time = viewModel.dueTime else { return "" }
+        let tf = DateFormatter()
+        tf.dateFormat = "h:mm a"
+        return tf.string(from: time)
     }
 
     private var recurringDisplayTitle: String {

--- a/docs/specs/bidirectional-sync-spec.md
+++ b/docs/specs/bidirectional-sync-spec.md
@@ -1,0 +1,297 @@
+# Bidirectional Sync Specification — Task <-> Calendar Event
+
+**Issue:** #283
+**Status:** Verification spec for existing implementation
+**Last updated:** 2026-03-15
+
+---
+
+## Overview
+
+Tasks with a due date, time, and estimated duration are eligible for auto-sync to a dedicated "Lazyflow" calendar in EventKit. Changes flow in both directions: task changes push to calendar events (forward sync), and external calendar edits pull back to tasks (reverse sync).
+
+---
+
+## Sync Eligibility
+
+A task is eligible for auto-sync when ALL of:
+- `dueDate != nil`
+- `dueTime != nil`
+- `estimatedDuration > 0`
+- `isCompleted == false`
+- `isArchived == false`
+
+**Settings required:** `calendarAutoSync == true` in UserDefaults.
+
+---
+
+## User Paths
+
+### P1: Create Task with Date/Time/Duration
+
+| Step | Action | Expected Forward Sync | Verified? |
+|------|--------|----------------------|-----------|
+| P1.1 | Create task with date + time + duration | New EKEvent created in Lazyflow calendar with matching title, start/end, notes | |
+| P1.2 | Create task with date + time but NO duration | No event created (not eligible) | |
+| P1.3 | Create task with date only (no time) | No event created (not eligible) | |
+| P1.4 | Create task with no date | No event created (not eligible) | |
+| P1.5 | Create task with date + time + duration + recurring rule | Event created with matching EKRecurrenceRule | |
+| P1.6 | Create task with intraday recurring rule (hourly/timesPerDay) | No recurrence rule on event (`canMapToEKRecurrenceRule == false`) | |
+| P1.7 | Create task when auto-sync is OFF | No event created | |
+| P1.8 | Create task when calendar access denied | No event created; graceful failure | |
+
+### P2: Update Task Title
+
+| Step | Action | Expected Forward Sync | Verified? |
+|------|--------|----------------------|-----------|
+| P2.1 | Edit title of linked task | Event title updated (unless busy-only mode) | |
+| P2.2 | Edit title of linked task in busy-only mode | Event title stays "Focus Block" | |
+| P2.3 | Edit title of unlinked task | No calendar change | |
+
+### P3: Update Task Notes
+
+| Step | Action | Expected Forward Sync | Verified? |
+|------|--------|----------------------|-----------|
+| P3.1 | Edit notes of linked task | Event notes updated (unless busy-only mode) | |
+| P3.2 | Edit notes in busy-only mode | Event notes stay empty | |
+
+### P4: Update Task Date/Time
+
+| Step | Action | Expected Forward Sync | Verified? |
+|------|--------|----------------------|-----------|
+| P4.1 | Change due date of linked task | Event start/end dates updated | |
+| P4.2 | Change due time of linked task | Event start time updated, end = start + duration | |
+| P4.3 | Remove due date from linked task | Task becomes ineligible; event should be unlinked or deleted | |
+| P4.4 | Remove due time from linked task | Task becomes ineligible; event should be unlinked or deleted | |
+| P4.5 | Change date via "Push to Tomorrow" swipe | Event rescheduled to tomorrow same time | |
+| P4.6 | Change date via DatePicker quick options (Today/Tomorrow/Next Week) | Event date updated accordingly | |
+
+### P5: Update Task Duration
+
+| Step | Action | Expected Forward Sync | Verified? |
+|------|--------|----------------------|-----------|
+| P5.1 | Increase duration of linked task | Event end time extended | |
+| P5.2 | Decrease duration of linked task | Event end time shortened | |
+| P5.3 | Set duration to 0 on linked task | Task becomes ineligible; event handling TBD | |
+
+### P6: Complete Task
+
+| Step | Action | Expected Forward Sync | Verified? |
+|------|--------|----------------------|-----------|
+| P6.1 | Complete linked task (policy: keepEvent) | Event title prefixed with checkmark | |
+| P6.2 | Complete linked task (policy: deleteEvent) | Event deleted from calendar | |
+| P6.3 | Complete recurring linked task (keepEvent) | Current event marked done; next occurrence created with inherited link | |
+| P6.4 | Complete recurring linked task (deleteEvent) | Current event deleted (thisEvent only); next occurrence created | |
+| P6.5 | Complete intraday task (increment) | No calendar change (intraday tasks may not have mappable events) | |
+| P6.6 | Uncomplete a previously completed task | Event title has checkmark removed OR event re-created | |
+| P6.7 | Auto-complete parent via subtask completion | Same as P6.1/P6.2 depending on policy | |
+
+### P7: Delete Task
+
+| Step | Action | Expected Forward Sync | Verified? |
+|------|--------|----------------------|-----------|
+| P7.1 | Swipe-delete linked task | Event deleted from calendar | |
+| P7.2 | Context menu delete linked task | Event deleted from calendar | |
+| P7.3 | Delete from task detail view | Event deleted from calendar | |
+| P7.4 | Undo delete (within undo window) | Event should be restored or re-created | |
+| P7.5 | Delete unlinked task | No calendar change | |
+| P7.6 | Delete recurring linked task | Only this event deleted (not series) | |
+
+### P8: Schedule Task via Calendar UI
+
+| Step | Action | Expected Forward Sync | Verified? |
+|------|--------|----------------------|-----------|
+| P8.1 | Schedule task via TimeBlockSheet | Event created; task linked with eventID | |
+| P8.2 | Schedule task via "Schedule to Calendar" context menu | TimeBlockSheet opens; same as P8.1 | |
+| P8.3 | Schedule task via swipe action | TimeBlockSheet opens; same as P8.1 | |
+| P8.4 | Schedule task that already has a linked event | Existing event updated or replaced | |
+
+### P9: Create Task from Calendar Event
+
+| Step | Action | Expected Forward Sync | Verified? |
+|------|--------|----------------------|-----------|
+| P9.1 | Create task from calendar event | Task created with isEventOwner=false, linked to event | |
+| P9.2 | Complete task created from event (keepEvent) | Event unchanged, task unlinked | |
+| P9.3 | Complete task created from event (deleteEvent) | Event unchanged, task unlinked | |
+| P9.4 | Delete task created from event | Event unchanged, task deleted | |
+| P9.5 | Edit title of task created from event | Event title NOT updated | |
+
+---
+
+## Reverse Sync Paths (Calendar -> Task)
+
+### R1: Edit Event in External Calendar App
+
+| Step | Action | Expected Reverse Sync | Verified? |
+|------|--------|----------------------|-----------|
+| R1.1 | Change event title in Apple Calendar | Task title updated (unless busy-only mode) | |
+| R1.2 | Change event start time in Apple Calendar | Task scheduledStartTime, dueDate, dueTime updated | |
+| R1.3 | Change event end time in Apple Calendar | Task scheduledEndTime, estimatedDuration updated | |
+| R1.4 | Drag event to different day in Apple Calendar | Task dueDate updated to new day | |
+| R1.5 | Drag event to different time in Apple Calendar | Task dueTime and scheduledStartTime updated | |
+| R1.6 | Change event notes in Apple Calendar | Task notes updated | |
+| R1.7 | Add recurrence rule in Apple Calendar | Task recurringRule populated (if mappable) | |
+| R1.8 | Change event title when busy-only is ON | Title change ignored (stays "Focus Block") | |
+
+### R2: Delete Event Externally
+
+| Step | Action | Expected Reverse Sync | Verified? |
+|------|--------|----------------------|-----------|
+| R2.1 | Delete linked event in Apple Calendar | Task links cleared (linkedEventID, calendarItemExternalIdentifier, lastSyncedAt) | |
+| R2.2 | Delete single occurrence of recurring event | Task for that occurrence unlinked | |
+| R2.3 | Delete all future events of recurring series | All linked task occurrences unlinked | |
+| R2.4 | Notification posted after external deletion | `.linkedEventDeletedExternally` with task title | |
+
+### R3: EventKit Store Churn (iCloud Sync)
+
+| Step | Action | Expected Reverse Sync | Verified? |
+|------|--------|----------------------|-----------|
+| R3.1 | iCloud reassigns eventIdentifier | Fallback lookup via calendarItemExternalIdentifier succeeds | |
+| R3.2 | Re-link task with new eventIdentifier | linkedEventID updated to new value | |
+| R3.3 | Both identifiers change (extreme churn) | Task unlinked (treated as external deletion) | |
+
+---
+
+## Loop Prevention
+
+| Guard | Condition | Behavior |
+|-------|-----------|----------|
+| Forward → Reverse block | Task pushed within last 10 seconds | Reverse sync skips this task |
+| Reverse → Forward block | Task reverse-synced within last 3 seconds | Forward sync skips this task |
+| Re-entrance guard | `isSyncing == true` | New sync request dropped |
+| Auto-sync check | `isAutoSyncEnabled == false` | All sync operations skipped |
+
+### LP1: Loop Prevention Scenarios
+
+| Step | Scenario | Expected Behavior | Verified? |
+|------|----------|-------------------|-----------|
+| LP1.1 | Edit task title, forward sync pushes to event, EKEventStoreChanged fires | Reverse sync skips (10s cooldown) | |
+| LP1.2 | External calendar edit triggers reverse sync, task updated, Core Data save fires | Forward sync skips (3s guard) | |
+| LP1.3 | Rapid successive edits to same task | Only latest state synced (1.5s debounce) | |
+| LP1.4 | Simultaneous forward and reverse sync attempts | `isSyncing` flag prevents re-entrance | |
+
+---
+
+## Edge Cases
+
+### E1: Timing & Concurrency
+
+| Step | Scenario | Expected Behavior | Verified? |
+|------|----------|-------------------|-----------|
+| E1.1 | Edit task while reverse sync in progress | Forward sync queued after reverse completes (debounce) | |
+| E1.2 | Calendar access revoked while sync running | Graceful failure; no crash | |
+| E1.3 | App backgrounded during sync | Sync completes or gracefully aborts | |
+| E1.4 | App killed during sync | Partial state; next launch re-syncs | |
+| E1.5 | Two devices edit same task/event simultaneously (via iCloud) | Last-write-wins; potential data loss | |
+
+### E2: Data Integrity
+
+| Step | Scenario | Expected Behavior | Verified? |
+|------|----------|-------------------|-----------|
+| E2.1 | Task eligible → edit removes date → becomes ineligible | Linked event should be deleted or unlinked | |
+| E2.2 | Task eligible → edit removes time → becomes ineligible | Same as E2.1 | |
+| E2.3 | Task eligible → edit sets duration to 0 → becomes ineligible | Same as E2.1 | |
+| E2.4 | Task archived while linked to event | Event should be deleted or unlinked | |
+| E2.5 | Lazyflow calendar deleted in Settings app | Events orphaned; tasks still have stale links | |
+| E2.6 | Event creation throws (calendar full, permissions) | Task NOT marked as synced; retry on next cycle | |
+| E2.7 | Event creation throws repeatedly | Infinite retry loop (no max retry count) | |
+
+### E3: Recurring Tasks
+
+| Step | Scenario | Expected Behavior | Verified? |
+|------|----------|-------------------|-----------|
+| E3.1 | Complete recurring task → next occurrence inherits link | New task has linkedEventID for next event in series | |
+| E3.2 | Complete intraday recurring task | No link inheritance (can't map to EKRecurrenceRule) | |
+| E3.3 | Change recurring rule on linked task | Event recurrence rule updated | |
+| E3.4 | Remove recurring rule from linked task | Event recurrence rule removed | |
+| E3.5 | Biweekly task → EKRecurrenceRule with interval 2 | Correct weekly rule with interval=2 | |
+
+### E4: Privacy & Display
+
+| Step | Scenario | Expected Behavior | Verified? |
+|------|----------|-------------------|-----------|
+| E4.1 | Enable busy-only mode on existing linked tasks | Next forward sync changes titles to "Focus Block" | |
+| E4.2 | Disable busy-only mode | Next forward sync restores real titles | |
+| E4.3 | External edit to "Focus Block" event title | Reverse sync should skip title update (busy-only guard) | |
+| E4.4 | User has existing "Focus Block" event (not from Lazyflow) | Potential false match on busy-only check | |
+
+### E5: CloudKit + EventKit Interaction
+
+| Step | Scenario | Expected Behavior | Verified? |
+|------|----------|-------------------|-----------|
+| E5.1 | Task synced via CloudKit to new device | New device re-links to calendar event via externalIdentifier | |
+| E5.2 | Calendar event synced via iCloud to new device | eventIdentifier may differ; externalIdentifier should match | |
+| E5.3 | Delete task on device A, event still on device B | Reverse sync on device B should detect orphaned event | |
+
+---
+
+## Settings Matrix
+
+| Setting | Values | Effect on Forward Sync | Effect on Reverse Sync |
+|---------|--------|----------------------|----------------------|
+| `calendarAutoSync` | true/false | Enables/disables all sync | Enables/disables reverse sync |
+| `calendarCompletionPolicy` | "keep"/"delete" | Keep event with checkmark vs delete on completion | N/A |
+| `calendarBusyOnly` | true/false | Use "Focus Block" as title | Skip title updates from calendar |
+
+---
+
+## Event Ownership
+
+### Concept
+Tasks can be linked to calendar events in two directions:
+- **Task → Event** (task created the event via auto-sync): `isEventOwner = true`
+- **Event → Task** (task created from calendar event): `isEventOwner = false`
+
+### Behavior Matrix
+
+| Action | isEventOwner = true | isEventOwner = false |
+|--------|-------------------|---------------------|
+| Forward sync (push updates) | Push title/notes/time changes | Skip (don't modify source event) |
+| Complete (keepEvent) | Prefix event with checkmark | Just unlink task |
+| Complete (deleteEvent) | Delete the event | Just unlink task |
+| Task becomes ineligible | Delete orphaned event | Just unlink task |
+| Delete task | Delete event (after undo window) | Just unlink task |
+| Event deleted externally | Unlink task | Unlink task |
+
+---
+
+## Known Gaps (from code review)
+
+| ID | Gap | Severity | Status |
+|----|-----|----------|--------|
+| G1 | No max retry for failed event creation → infinite retry loop | Medium | Open |
+| G2 | No conflict resolution when task AND event both modified | Medium | Open |
+| G3 | Task becoming ineligible (date/time/duration removed) doesn't clean up linked event | High | Fixed |
+| G4 | Lazyflow calendar deletion not handled (stale links persist) | Medium | Open |
+| G5 | No logging/metrics for sync operations | Low | Open |
+| G6 | "Focus Block" title collision with user's real events | Low | Open |
+| G7 | Undo-delete doesn't restore calendar event | Medium | Fixed |
+| G8 | Uncomplete task doesn't restore deleted event (deleteEvent policy) | Medium | Needs verification |
+| G9 | No event ownership tracking — completing/deleting task-from-event can modify/delete the source event | High | In progress |
+
+---
+
+## Test Plan
+
+### Unit Tests (CalendarSyncServiceTests)
+
+Mock `CalendarServiceProtocol` and `TaskServiceProtocol` to test:
+- Forward sync for each P1-P8 path
+- Reverse sync for each R1-R3 path
+- Loop prevention for each LP1 scenario
+- Edge cases E1-E5
+
+### Integration Tests
+
+With real Core Data stack + mock EventKit:
+- End-to-end create → sync → edit → re-sync flows
+- Completion → event cleanup flows
+- Deletion → event cleanup flows
+
+### Manual QA (Physical Device)
+
+- Create task in Lazyflow → verify event in Apple Calendar
+- Edit event in Apple Calendar → verify task updated in Lazyflow
+- Delete event in Apple Calendar → verify task unlinked
+- Complete task → verify event marked/deleted per policy
+- Test with iCloud calendar enabled across two devices


### PR DESCRIPTION
## Summary
- Split overloaded ScheduleSheet into three focused sheets:
  - **DatePickerSheet**: graphical calendar only (quick chips already in main view)
  - **TimeBlockSheet**: start time wheel + quick chips (Morning/Afternoon/Evening)
  - **DurationPickerSheet**: preset chips + custom hours/minutes wheels
- Reorder quick action rows: Today/Date/Time → Duration/Priority/Category → List/Remind/Repeat
- Remove Tomorrow button (redundant with Date picker)
- Separate Time and Duration chips with independent clear actions
- Rename CalendarView's TimeBlockSheet to CalendarTimeBlockSheet to avoid collision
- Add bidirectional sync spec document

## Test plan
- [ ] Tap Date → shows graphical calendar picker
- [ ] Tap Time → shows quick time chips + wheel picker, auto-fills today + next 15-min slot
- [ ] Tap Duration → shows preset chips + custom hours/minutes wheels
- [ ] Time chip shows formatted time, clearing removes time only
- [ ] Duration chip shows formatted duration, clearing removes duration only
- [ ] Today button sets date with one tap (no sheet)
- [ ] All three sheets render cleanly without overlapping content or empty gaps

Closes #290