### PR TITLE
fix(ci): version bump rides the release PR instead of post-release push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,19 +51,17 @@ jobs:
           gh release edit "$TAG" --title "$NEW_TITLE"
           echo "Updated release title to: $NEW_TITLE"
 
-      - name: Update version across project
-        run: ./scripts/bump-version.sh ${{ needs.release-please.outputs.version }}
-
-      - name: Generate App Store release notes from CHANGELOG
-        run: ./scripts/generate-release-notes.sh ${{ needs.release-please.outputs.version }}
-
-      - name: Commit version update
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "chore: bump iOS version to ${{ needs.release-please.outputs.version }}"
-          git push
+      # NOTE: the version bump and App Store release notes are NOT applied
+      # here anymore. Branch protection (correctly) rejects this job's direct
+      # push to main (GH006, seen live on v1.11.0), and a bot push couldn't
+      # trigger checks anyway. Instead, both must be committed to the
+      # release-please branch BEFORE merging — the check-metadata required
+      # check enforces this (scripts/check-release-metadata.sh validates
+      # release notes AND MARKETING_VERSION). Run on the release branch:
+      #   ./scripts/bump-version.sh <version>
+      #   ./scripts/generate-release-notes.sh <version>   # then polish by hand
+      # This also fixes a latent ordering bug: TestFlight used to build BEFORE
+      # the bump landed, shipping the old marketing version.
 
   testflight:
     needs: [release-please, post-release]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,13 +96,18 @@ Milestone-based release lifecycle with Release Please:
 Issues in milestone (e.g., v1.8)
   → Feature branches per issue → PRs merged to main
     → Release Please auto-creates/updates release PR
-      → Developer merges Release Please PR (decision point 1)
-        → CI: GitHub Release + tag + version bump + TestFlight build
-          → Developer updates promotional_text.txt (decision point 2)
-            → Developer triggers App Store workflow (decision point 3)
+      → On the release branch: run bump-version.sh + generate-release-notes.sh,
+        polish notes, commit (check-metadata BLOCKS the merge without this)
+        → Developer merges Release Please PR (decision point 1)
+          → CI: GitHub Release + tag + TestFlight build
+            → Developer updates promotional_text.txt (decision point 2)
+              → Developer triggers App Store workflow (decision point 3)
 ```
 
 Three human decisions in the entire pipeline. Everything else is automated.
+Note: bot pushes never trigger CI (GITHUB_TOKEN recursion guard) — after
+Release Please updates its branch, required checks need an authored commit
+(the bump/notes commit above serves this purpose).
 
 ## Multi-Agent Setup
 

--- a/scripts/check-release-metadata.sh
+++ b/scripts/check-release-metadata.sh
@@ -62,6 +62,19 @@ check_file() {
 check_file "fastlane/metadata/en-US/release_notes.txt"   "release_notes.txt"
 check_file "fastlane/metadata/en-US/testflight_notes.txt" "testflight_notes.txt"
 
+# The version bump must ride the release PR: the Release workflow cannot
+# push it to main afterward (branch protection rejects bot pushes), and
+# TestFlight builds from the merge commit — so MARKETING_VERSION must
+# already be correct here.
+if grep -q "MARKETING_VERSION: ${VERSION}" project.yml; then
+    echo -e "${GREEN}PASS${NC} project.yml MARKETING_VERSION is ${VERSION}"
+else
+    CURRENT=$(grep "MARKETING_VERSION:" project.yml | head -1 | awk '{print $2}')
+    echo -e "${RED}FAIL${NC} project.yml MARKETING_VERSION is ${CURRENT}, expected ${VERSION}"
+    echo -e "${YELLOW}     Run ./scripts/bump-version.sh ${VERSION} and commit to the release branch.${NC}"
+    FAILED=1
+fi
+
 echo ""
 if [ "$FAILED" -ne 0 ]; then
     echo -e "${RED}Release metadata is stale. Update the files above for v${VERSION} and push to the release branch.${NC}"


### PR DESCRIPTION
See commit message — replaces the protected-branch push (GH006 on v1.11.0) with enforcement via the existing check-metadata gate, and fixes the latent TestFlight-builds-old-version ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)